### PR TITLE
Cleanup of RC button positions for Beyonwiz-branded ini5 remote.

### DIFF
--- a/BoxBranding/remotes/ini5/rcpositions.xml
+++ b/BoxBranding/remotes/ini5/rcpositions.xml
@@ -17,9 +17,10 @@
 		<button name="VOL-" pos="22,303" />
 		<button name="MUTE" pos="55,287" />
 		<button name="EXIT" pos="95,212" />
-		<button name="BOUQUET+" pos="89,273" />
-		<button name="BOUQUET-" pos="89,303" />
-		<button name="INFO" pos="22,147" />
+		<button name="CH+" pos="89,273" />
+		<button name="CH-" pos="89,303" />
+		<button name="INFO" pos="22,244" />
+		<button name="BACK" pos="89,244" />
 		<button name="MENU" pos="22,212" />
 		<button name="OK" pos="57,180" />
 		<button name="UP" pos="57,154" />
@@ -35,12 +36,10 @@
 		<button name="RADIO" pos="67,415" />
 		<button name="TEXT" pos="22,414" />
 		<button name="HELP" pos="92,414" />
-		<button name="PVR" pos="60,244" />
 		<button name="RECORD" pos="23,371" />
-		<button name="PLAY" pos="47,351" />
-		<button name="PAUSE" pos="47,351" />
+		<button name="PLAYPAUSE" pos="47,351" />
 		<button name="REWIND" pos="22,351" />
-		<button name="FORWARD" pos="95,351" />
+		<button name="FASTFORWARD" pos="95,351" />
 		<button name="STOP" pos="71,351" />
 		<button name="WWW" pos="67,369" />
 		<button name="PLUGIN" pos="91,369" />


### PR DESCRIPTION
Needed for Beyonwiz T3 bugtracker bug #301 - Help menu in main screen errors (Part of fix)

Moved button to correct location: INFO
Removed buttons not in Tools.KeyBindings for T3: PVR, PLAY, PAUSE
Renamed buttons with wrong naming for Tools.KeyBindings:
    BOUQUET+/BOUQUET- -> CH+/CH-
    FORWARD -> FASTFORWARD
Added missing buttons: BACK, PLAYPAUSE

Similar changes may also be needed in RC button positions for remotes
ini3 and ini4, but I have no access to those remotes or the systems that
use them.

This fix can be applied independently of other changes needed to
fix bug #301.
