### PR TITLE
Prevent memory leaks and buffer overruns and fix compiler warnings.

### DIFF
--- a/BoxBranding/lib/_boxbranding.c
+++ b/BoxBranding/lib/_boxbranding.c
@@ -5,140 +5,66 @@
 #include <Python.h>
 #include "boxbranding.h"
 
+#define MAKE_STRING_FUNCTION(name) \
+static PyObject* name(PyObject* self, PyObject* args) \
+{ \
+	PyObject* res; \
+	char *s = _##name(); \
+	res = Py_BuildValue("s", s); \
+	free(s); \
+	return res; \
+} \
+
 /* Available functions */
-static PyObject* getMachineProcModel(PyObject* self)
-{
-    return Py_BuildValue("s", _getMachineProcModel());
-}
-
-static PyObject* getMachineBrand(PyObject* self)
-{
-    return Py_BuildValue("s", _getMachineBrand());
-}
- 
-static PyObject* getMachineName(PyObject* self)
-{
-    return Py_BuildValue("s", _getMachineName());
-}
-
-static PyObject* getMachineBuild(PyObject* self)
-{
-    return Py_BuildValue("s", _getMachineBuild());
-}
-
-static PyObject* getMachineMake(PyObject* self)
-{
-    return Py_BuildValue("s", _getMachineMake());
-}
-
-static PyObject* getMachineMtdRoot(PyObject* self)
-{
-    return Py_BuildValue("s", _getMachineMtdRoot());
-}
-
-static PyObject* getMachineMtdKernel(PyObject* self)
-{
-    return Py_BuildValue("s", _getMachineMtdKernel());
-}
-
-static PyObject* getMachineRootFile(PyObject* self)
-{
-    return Py_BuildValue("s", _getMachineRootFile());
-}
-
-static PyObject* getMachineKernelFile(PyObject* self)
-{
-    return Py_BuildValue("s", _getMachineKernelFile());
-}
-
-static PyObject* getMachineMKUBIFS(PyObject* self)
-{
-    return Py_BuildValue("s", _getMachineMKUBIFS());
-}
-
-static PyObject* getMachineUBINIZE(PyObject* self)
-{
-    return Py_BuildValue("s", _getMachineUBINIZE());
-}
-
-static PyObject* getBoxType(PyObject* self)
-{
-    return Py_BuildValue("s", _getBoxType());
-}
-
-static PyObject* getBrandOEM(PyObject* self)
-{
-    return Py_BuildValue("s", _getBrandOEM());
-}
-
-static PyObject* getOEVersion(PyObject* self)
-{
-    return Py_BuildValue("s", _getOEVersion());
-}
-
-static PyObject* getDriverDate(PyObject* self)
-{
-    return Py_BuildValue("s", _getDriverDate());
-}
-
-static PyObject* getImageVersion(PyObject* self)
-{
-    return Py_BuildValue("s", _getImageVersion());
-}
-
-static PyObject* getImageBuild(PyObject* self)
-{
-    return Py_BuildValue("s", _getImageBuild());
-}
-
-static PyObject* getImageType(PyObject* self)
-{
-    return Py_BuildValue("s", _getImageType());
-}
-
-static PyObject* getImageDistro(PyObject* self)
-{
-    return Py_BuildValue("s", _getImageDistro());
-}
-
-static PyObject* getImageFolder(PyObject* self)
-{
-    return Py_BuildValue("s", _getImageFolder());
-}
-
-static PyObject* getImageFileSystem(PyObject* self)
-{
-    return Py_BuildValue("s", _getImageFileSystem());
-}
+MAKE_STRING_FUNCTION(getMachineBuild)
+MAKE_STRING_FUNCTION(getMachineMake)
+MAKE_STRING_FUNCTION(getMachineProcModel)
+MAKE_STRING_FUNCTION(getMachineBrand)
+MAKE_STRING_FUNCTION(getMachineName)
+MAKE_STRING_FUNCTION(getMachineMtdRoot)
+MAKE_STRING_FUNCTION(getMachineKernelFile)
+MAKE_STRING_FUNCTION(getMachineRootFile)
+MAKE_STRING_FUNCTION(getMachineMtdKernel)
+MAKE_STRING_FUNCTION(getMachineMKUBIFS)
+MAKE_STRING_FUNCTION(getMachineUBINIZE)
+MAKE_STRING_FUNCTION(getBoxType)
+MAKE_STRING_FUNCTION(getBrandOEM)
+MAKE_STRING_FUNCTION(getOEVersion)
+MAKE_STRING_FUNCTION(getDriverDate)
+MAKE_STRING_FUNCTION(getImageVersion)
+MAKE_STRING_FUNCTION(getImageBuild)
+MAKE_STRING_FUNCTION(getImageType)
+MAKE_STRING_FUNCTION(getImageDistro)
+MAKE_STRING_FUNCTION(getImageFolder)
+MAKE_STRING_FUNCTION(getImageFileSystem)
 
 /* Module specification */
 static PyMethodDef boxbrandingMethods[] = {
-	{ "getMachineBuild", getMachineBuild, METH_NOARGS },
-	{ "getMachineMake", getMachineMake, METH_NOARGS },
-	{ "getMachineProcModel", getMachineProcModel, METH_NOARGS },  
-	{ "getMachineBrand", getMachineBrand, METH_NOARGS },
-	{ "getMachineName", getMachineName, METH_NOARGS },
-	{ "getMachineMtdRoot", getMachineMtdRoot, METH_NOARGS },
-	{ "getMachineKernelFile", getMachineKernelFile, METH_NOARGS },
-	{ "getMachineRootFile", getMachineRootFile, METH_NOARGS },
-	{ "getMachineMtdKernel", getMachineMtdKernel, METH_NOARGS },
-	{ "getMachineMKUBIFS", getMachineMKUBIFS, METH_NOARGS },
-	{ "getMachineUBINIZE", getMachineUBINIZE, METH_NOARGS },
-	{ "getBoxType", getBoxType, METH_NOARGS },
-	{ "getBrandOEM", getBrandOEM, METH_NOARGS },
-	{ "getOEVersion", getOEVersion, METH_NOARGS },
-	{ "getDriverDate", getDriverDate, METH_NOARGS },
-	{ "getImageVersion", getImageVersion, METH_NOARGS },
-	{ "getImageBuild", getImageBuild, METH_NOARGS },
-	{ "getImageType", getImageType, METH_NOARGS },
-	{ "getImageDistro", getImageDistro, METH_NOARGS },
-	{ "getImageFolder", getImageFolder, METH_NOARGS },
-	{ "getImageFileSystem", getImageFileSystem, METH_NOARGS },
-	{ NULL, NULL }
+	{ "getMachineBuild", getMachineBuild, METH_NOARGS, NULL },
+	{ "getMachineMake", getMachineMake, METH_NOARGS, NULL },
+	{ "getMachineProcModel", getMachineProcModel, METH_NOARGS, NULL },
+	{ "getMachineBrand", getMachineBrand, METH_NOARGS, NULL },
+	{ "getMachineName", getMachineName, METH_NOARGS, NULL },
+	{ "getMachineMtdRoot", getMachineMtdRoot, METH_NOARGS, NULL },
+	{ "getMachineKernelFile", getMachineKernelFile, METH_NOARGS, NULL },
+	{ "getMachineRootFile", getMachineRootFile, METH_NOARGS, NULL },
+	{ "getMachineMtdKernel", getMachineMtdKernel, METH_NOARGS, NULL },
+	{ "getMachineMKUBIFS", getMachineMKUBIFS, METH_NOARGS, NULL },
+	{ "getMachineUBINIZE", getMachineUBINIZE, METH_NOARGS, NULL },
+	{ "getBoxType", getBoxType, METH_NOARGS, NULL },
+	{ "getBrandOEM", getBrandOEM, METH_NOARGS, NULL },
+	{ "getOEVersion", getOEVersion, METH_NOARGS, NULL },
+	{ "getDriverDate", getDriverDate, METH_NOARGS, NULL },
+	{ "getImageVersion", getImageVersion, METH_NOARGS, NULL },
+	{ "getImageBuild", getImageBuild, METH_NOARGS, NULL },
+	{ "getImageType", getImageType, METH_NOARGS, NULL },
+	{ "getImageDistro", getImageDistro, METH_NOARGS, NULL },
+	{ "getImageFolder", getImageFolder, METH_NOARGS, NULL },
+	{ "getImageFileSystem", getImageFileSystem, METH_NOARGS, NULL },
+	{ NULL, NULL, 0, NULL }
 };
 
 /* Initialize the module */
 void initboxbranding() {
-	PyObject *m;
-	m = Py_InitModule("boxbranding", boxbrandingMethods);
-} 
+	Py_InitModule("boxbranding", boxbrandingMethods);
+}

--- a/BoxBranding/lib/boxbranding.c
+++ b/BoxBranding/lib/boxbranding.c
@@ -4,15 +4,6 @@
 #include <sys/stat.h>
 #include "boxbranding.h"
 
-/* TODO: Change the API so that the caller is always responsible for
- * calling free() on the returned string.
- *
- * At the moment, the API returns a mixture of strings created using
- * malloc() and pointers to static data. The new API should continue
- * to return the malloc() created strings and use strdup() before
- * returning the static strings.
- */
-
 /** detecting whether base is starts with str
  */
 bool startsWith (char* base, char* str)
@@ -79,11 +70,10 @@ char* ReadProcEntry(char *filename)
 	return real_boxtype_name;
 }
 
-const char *_getBoxType()	// this will try to find the correct BOX MACHINE e.x MACHINE=ventonhdx DISTRO=openvix -> it will return uniboxhd1   for a UniBox HD1
+char *_getBoxType()	// this will try to find the correct BOX MACHINE e.x MACHINE=ventonhdx DISTRO=openvix -> it will return uniboxhd1   for a UniBox HD1
 {
 	// this ugly code will be removed after we will switch tottaly to OE-A 2.0
 	char *boxtype_name = NULL;
-	char *vu_boxtype_name = NULL;
 
 	if(strcmp(BOXTYPE, "xpeedlx") == 0)
 	{
@@ -91,7 +81,7 @@ const char *_getBoxType()	// this will try to find the correct BOX MACHINE e.x M
 		if(strcmp(boxtype_name, "ini-1000lx") == 0)
 		{
 			free(boxtype_name);
-			return "xpeedlx2t";
+			return strdup("xpeedlx2t");
 		}
 		else if(strcmp(boxtype_name, "ini-1000de") == 0)
 		{
@@ -100,12 +90,12 @@ const char *_getBoxType()	// this will try to find the correct BOX MACHINE e.x M
 			if(startsWith(boxtype_name, "2"))
 			{
 				free(boxtype_name);
-				return "xpeedlx2";
+				return strdup("xpeedlx2");
 			}
 			else
 			{
 				free(boxtype_name);
-				return "xpeedlx1";
+				return strdup("xpeedlx1");
 			}
 		}
 	}
@@ -115,39 +105,35 @@ const char *_getBoxType()	// this will try to find the correct BOX MACHINE e.x M
 		if(strcmp(boxtype_name, "ini-3000") == 0)
 		{
 			free(boxtype_name);
-			return "uniboxhd1";
+			return strdup("uniboxhd1");
 		}
 		else if(strcmp(boxtype_name, "ini-5000") == 0)
 		{
 			free(boxtype_name);
-			return "uniboxhd2";
+			return strdup("uniboxhd2");
 		}
 		else if(strcmp(boxtype_name, "ini-7000") == 0)
 		{
 			free(boxtype_name);
-			return "uniboxhd3";
+			return strdup("uniboxhd3");
 		}
 		else if(strcmp(boxtype_name, "ini-7012") == 0)
 		{
 			free(boxtype_name);
-			return "uniboxhd3";
+			return strdup("uniboxhd3");
 		}
 	}
 	else if(strcmp(BOXTYPE, "et6x00") == 0 || strcmp(BOXTYPE, "et9x00") == 0 || strcmp(BOXTYPE, "et7x00") == 0)
 	{
 		boxtype_name = ReadProcEntry("/proc/stb/info/boxtype");
-		// TODO: Change API so that caller must free() the string, otherwise this will leak the memory allocated in ReadProcEntry.
 		return boxtype_name;
 	}
-	else
-	{
-		return BOXTYPE;
-	}
+	return strdup(BOXTYPE);
 }
 
 /** detecting real Box Name for OSD Translations
  */
-const char *_getMachineName()
+char *_getMachineName()
 {
 	char *boxtype_name = NULL;
 	if(fileExist("/proc/stb/info/boxtype"))
@@ -157,161 +143,153 @@ const char *_getMachineName()
 		if(strcmp(boxtype_name, "ini-3000") == 0)
 		{
 			free(boxtype_name);
-			return "HD-1";
+			return strdup("HD-1");
 		}
 		else if(strcmp(boxtype_name, "ini-5000") == 0)
 		{
 			free(boxtype_name);
-			return "HD-2";
+			return strdup("HD-2");
 		}
 		else if(strcmp(boxtype_name, "ini-7000") == 0)
 		{
 			free(boxtype_name);
-			return "HD-3";
+			return strdup("HD-3");
 		}
 		else if(strcmp(boxtype_name, "ini-7012") == 0)
 		{
 			free(boxtype_name);
-			return "HD-3";
+			return strdup("HD-3");
 		}
 		else if(strcmp(boxtype_name, "ini-1000lx") == 0)
 		{
 			free(boxtype_name);
-			return "LX-2T";
+			return strdup("LX-2T");
 		}
 		/** XTREND DETECTION */
 		else if(strcmp(boxtype_name, "et4x00") == 0)
 		{
 			free(boxtype_name);
-			return "ET4x00";
+			return strdup("ET4x00");
 		}
 		else if(strcmp(boxtype_name, "et4000") == 0)
 		{
 			free(boxtype_name);
-			return "ET4000";
+			return strdup("ET4000");
 		}
 		else if(strcmp(boxtype_name, "et5x00") == 0)
 		{
 			free(boxtype_name);
-			return "ET5x00";
+			return strdup("ET5x00");
 		}
 		else if(strcmp(boxtype_name, "et5000") == 0)
 		{
 			free(boxtype_name);
-			return "ET5000";
+			return strdup("ET5000");
 		}
 		else if(strcmp(boxtype_name, "et6000") == 0)
 		{
 			free(boxtype_name);
-			return "ET6000";
+			return strdup("ET6000");
 		}
 		else if(strcmp(boxtype_name, "et6500") == 0)
 		{
 			free(boxtype_name);
-			return "ET6500";
+			return strdup("ET6500");
 		}
 		else if(strcmp(boxtype_name, "et7000") == 0)
 		{
 			free(boxtype_name);
-			return "ET7000";
+			return strdup("ET7000");
 		}
 		else if(strcmp(boxtype_name, "et7500") == 0)
 		{
 			free(boxtype_name);
-			return "ET7500";
+			return strdup("ET7500");
 		}
 		else if(strcmp(boxtype_name, "et9x00") == 0)
 		{
 			free(boxtype_name);
-			return "ET9x00";
+			return strdup("ET9x00");
 		}
 		else if(strcmp(boxtype_name, "et9000") == 0)
 		{
 			free(boxtype_name);
-			return "ET9000";
+			return strdup("ET9000");
 		}
 		else if(strcmp(boxtype_name, "et9200") == 0)
 		{
 			free(boxtype_name);
-			return "ET9200";
+			return strdup("ET9200");
 		}
 		else if(strcmp(boxtype_name, "et9500") == 0)
 		{
 			free(boxtype_name);
-			return "ET9500";
+			return strdup("ET9500");
 		}
 		else /** if there is not matching STB name, return value from proc */
 		{
+			/*
+			 * TODO: The comment above and the code disagree.
+			 *
+			 * Which should it be? Right now it's the compile time string supplied via configure.
+			 */
 			free(boxtype_name);
-			return MACHINE_NAME;
+			return strdup(MACHINE_NAME);
 		}
 	}
 	/** AzBOX DETECTION */
-	else if(fileExist("/proc/stb/info/azmodel"))
+	else if (fileExist("/proc/stb/info/azmodel") && fileExist("/proc/stb/info/model"))
 	{
-		if(fileExist("/proc/stb/info/model"))
+		boxtype_name = ReadProcEntry("/proc/stb/info/model");
+		if(strcmp(boxtype_name, "me") == 0)
 		{
-			boxtype_name = ReadProcEntry("/proc/stb/info/model");
-			if(strcmp(boxtype_name, "me") == 0)
-			{
-				free(boxtype_name);
-				return "Me";
-			}
-			else if(strcmp(boxtype_name, "minime") == 0)
-			{
-				free(boxtype_name);
-				return "Mini Me";
-			}
-			else if(strcmp(boxtype_name, "premium") == 0)
-			{
-				free(boxtype_name);
-				return "Premium";
-			}
-			else if(strcmp(boxtype_name, "premium+") == 0)
-			{
-				free(boxtype_name);
-				return "Premium+";
-			}
-			else if(strcmp(boxtype_name, "elite") == 0)
-			{
-				free(boxtype_name);
-				return "Elite";
-			}
-			else if(strcmp(boxtype_name, "ultra") == 0)
-			{
-				free(boxtype_name);
-				return "Ultra";
-			}
-			else
-			{
-				free(boxtype_name);
-				return MACHINE_NAME;
-			}
+			free(boxtype_name);
+			return strdup("Me");
+		}
+		else if(strcmp(boxtype_name, "minime") == 0)
+		{
+			free(boxtype_name);
+			return strdup("Mini Me");
+		}
+		else if(strcmp(boxtype_name, "premium") == 0)
+		{
+			free(boxtype_name);
+			return strdup("Premium");
+		}
+		else if(strcmp(boxtype_name, "premium+") == 0)
+		{
+			free(boxtype_name);
+			return strdup("Premium+");
+		}
+		else if(strcmp(boxtype_name, "elite") == 0)
+		{
+			free(boxtype_name);
+			return strdup("Elite");
+		}
+		else if(strcmp(boxtype_name, "ultra") == 0)
+		{
+			free(boxtype_name);
+			return strdup("Ultra");
 		}
 		else
 		{
-			return MACHINE_NAME;
+			free(boxtype_name);
 		}
 	}
-	else
-	{
-		return MACHINE_NAME;
-	}
+	return strdup(MACHINE_NAME);
 }
 
-const char *_getMachineBrand()
+char *_getMachineBrand()
 {
-	char *boxtype_name = NULL;
-
-	return MACHINE_BRAND;
+	return strdup(MACHINE_BRAND);
 }
 
-const char *_getBrandOEM()
+char *_getBrandOEM()
 {
-	return BRAND_OEM;
+	return strdup(BRAND_OEM);
 }
 
-const char *_getDriverDate()
+char *_getDriverDate()
 {
 	FILE *driver_file;
 	int len = 0;
@@ -341,12 +319,12 @@ const char *_getDriverDate()
 			}
 			else
 			{
-				return DRIVERDATE;
+				return strdup(DRIVERDATE);
 			}
 		}
 		else // if it is not INI box, but use same proc entry, just return passed from BB drivers date
 		{
-			return DRIVERDATE;
+			return strdup(DRIVERDATE);
 		}
 	}
 	/** DAGS has in each driver build date - NO NEEED TAKE IT FROM BB FILE*/
@@ -370,98 +348,97 @@ const char *_getDriverDate()
 		}
 		else
 		{
-			return DRIVERDATE;
+			return strdup(DRIVERDATE);
 		}
 	}
 	else
 	{
-		return DRIVERDATE;
+		return strdup(DRIVERDATE);
 	}
 }
 
-const char *_getImageVersion()
+char *_getImageVersion()
 {
-	return IMAGEVERSION;
+	return strdup(IMAGEVERSION);
 }
 
-const char *_getImageBuild()
+char *_getImageBuild()
 {
-	return IMAGEBUILD;
+	return strdup(IMAGEBUILD);
 }
 
-const char *_getImageType()
+char *_getImageType()
 {
-	return DISTRO_TYPE;
+	return strdup(DISTRO_TYPE);
 }
 
-const char *_getImageDistro()
+char *_getImageDistro()
 {
-	return DISTRO;
+	return strdup(DISTRO);
 }
 
-const char *_getImageFolder()
+char *_getImageFolder()
 {
-	return IMAGEDIR;
+	return strdup(IMAGEDIR);
 }
 
-const char *_getImageFileSystem()
+char *_getImageFileSystem()
 {
-	return IMAGE_FSTYPES;
+	return strdup(IMAGE_FSTYPES);
 }
 
-const char *_getOEVersion()
+char *_getOEVersion()
 {
-	return OE_VER;
+	return strdup(OE_VER);
 }
 
-const char *_getMachineBuild()
+char *_getMachineBuild()
 {
 	// this will return BUILD MACHINE e.x MACHINE=mbtwin DISTRO=openvix -> it will return inihdx
-	return MACHINE_BUILD;
+	return strdup(MACHINE_BUILD);
 }
 
-const char *_getMachineMake()
+char *_getMachineMake()
 {
 	// this will return MAKE MACHINE e.x MACHINE=mbtwin DISTRO=openvix -> it will return mbtwin
-	return MACHINE_MAKE;
+	return strdup(MACHINE_MAKE);
 }
 
-const char *_getMachineMtdRoot()
+char *_getMachineMtdRoot()
 {
-	return MTD_ROOTFS;
+	return strdup(MTD_ROOTFS);
 }
 
-const char *_getMachineRootFile()
+char *_getMachineRootFile()
 {
-	return ROOTFS_FILE;
+	return strdup(ROOTFS_FILE);
 }
 
-const char *_getMachineMtdKernel()
+char *_getMachineMtdKernel()
 {
-	return MTD_KERNEL;
+	return strdup(MTD_KERNEL);
 }
 
-const char *_getMachineKernelFile()
+char *_getMachineKernelFile()
 {
-	return KERNEL_FILE;
+	return strdup(KERNEL_FILE);
 }
 
-const char *_getMachineMKUBIFS()
+char *_getMachineMKUBIFS()
 {
-	return MKUBIFS_ARGS;
+	return strdup(MKUBIFS_ARGS);
 }
 
-const char *_getMachineUBINIZE()
+char *_getMachineUBINIZE()
 {
-	return UBINIZE_ARGS;
+	return strdup(UBINIZE_ARGS);
 }
 
-const char *_getMachineProcModel() // return just value from proc entry
+char *_getMachineProcModel() // return just value from proc entry
 {
 	FILE *boxtype_file;
 	char boxtype_name[20];
 	char *real_boxtype_name = NULL;
-	char *vu_boxtype_name = NULL;
 	int len;
 
 	if((boxtype_file = fopen("/proc/stb/info/hwmodel", "r")) != NULL)
@@ -526,7 +503,7 @@ const char *_getMachineProcModel() // return just value from proc entry
 		}
 		else
 		{
-			return MACHINE_NAME;
+			return strdup(MACHINE_NAME);
 		}
 	}
 	/** VU+ DETECTION */
@@ -535,22 +512,13 @@ const char *_getMachineProcModel() // return just value from proc entry
 		fgets(boxtype_name, sizeof(boxtype_name), boxtype_file);
 		fclose(boxtype_file);
 
-		real_boxtype_name = malloc(strlen(boxtype_name) + 1);
+		real_boxtype_name = malloc(strlen(boxtype_name) + 3);
 		if (real_boxtype_name)
-			strcpy(real_boxtype_name, boxtype_name);
+			sprintf(real_boxtype_name, "vu%s", boxtype_name);
 		len = strlen(real_boxtype_name);
 		if (len > 0 && real_boxtype_name[len - 1 ] == '\n')
 			real_boxtype_name[len - 1] = '\0';
-
-		sprintf(real_boxtype_name, "vu%s", boxtype_name);
-
-		vu_boxtype_name = malloc(strlen(real_boxtype_name) + 1);
-		if (vu_boxtype_name)
-			strcpy(vu_boxtype_name, real_boxtype_name);
-		len = strlen(vu_boxtype_name);
-		if (len > 0 && vu_boxtype_name[len - 1 ] == '\n')
-			vu_boxtype_name[len - 1] = '\0';
-		return vu_boxtype_name;
+		return real_boxtype_name;
 	}
 	/** DMM DETECTION */
 	else
@@ -567,9 +535,6 @@ const char *_getMachineProcModel() // return just value from proc entry
 				real_boxtype_name[len - 1] = '\0';
 			return real_boxtype_name;
 		}
-		else
-		{
-			return MACHINE_NAME;
-		}
 	}
+	return strdup(MACHINE_NAME);
 }

--- a/BoxBranding/lib/boxbranding.c
+++ b/BoxBranding/lib/boxbranding.c
@@ -4,16 +4,25 @@
 #include <sys/stat.h>
 #include "boxbranding.h"
 
+/* TODO: Change the API so that the caller is always responsible for
+ * calling free() on the returned string.
+ *
+ * At the moment, the API returns a mixture of strings created using
+ * malloc() and pointers to static data. The new API should continue
+ * to return the malloc() created strings and use strdup() before
+ * returning the static strings.
+ */
+
 /** detecting whether base is starts with str
  */
-bool startsWith (char* base, char* str) 
+bool startsWith (char* base, char* str)
 {
     return (strstr(base, str) - base) == 0;
 }
 
 /** detecting whether base is ends with str
  */
-bool endsWith (char* base, char* str) 
+bool endsWith (char* base, char* str)
 {
     int blen = strlen(base);
     int slen = strlen(str);
@@ -34,6 +43,8 @@ int fileExist(const char* filename){
 }
 
 /** reading file and return value from it
+ * This function allocates memory for the returned string.
+ * The caller must call free() to prevent memory leaks.
  * */
 char* ReadProcEntry(char *filename)
 {
@@ -42,7 +53,7 @@ char* ReadProcEntry(char *filename)
 	char *real_boxtype_name = NULL;
 	char c;
 	int i = 0;
-	
+
 	if(boxtype_file)
 	{
 		while ((c = fgetc(boxtype_file)) != EOF && i < sizeof(boxtype_name) - 2)
@@ -59,12 +70,12 @@ char* ReadProcEntry(char *filename)
 		real_boxtype_name = malloc(strlen(boxtype_name) + 1);
 		if (real_boxtype_name)
 			strcpy(real_boxtype_name, boxtype_name);
-		
+
 		fclose(boxtype_file);
 	}
 	else
 		puts("[BRANDING] Can not open this proc entry!\n");
-	
+
 	return real_boxtype_name;
 }
 
@@ -73,55 +84,64 @@ const char *_getBoxType()	// this will try to find the correct BOX MACHINE e.x M
 	// this ugly code will be removed after we will switch tottaly to OE-A 2.0
 	char *boxtype_name = NULL;
 	char *vu_boxtype_name = NULL;
-	
+
 	if(strcmp(BOXTYPE, "xpeedlx") == 0)
 	{
 		boxtype_name = ReadProcEntry("/proc/stb/info/boxtype");
-		if(strcmp(boxtype_name, "ini-1000lx") == 0) 
+		if(strcmp(boxtype_name, "ini-1000lx") == 0)
 		{
+			free(boxtype_name);
 			return "xpeedlx2t";
 		}
-		else if(strcmp(boxtype_name, "ini-1000de") == 0) 
+		else if(strcmp(boxtype_name, "ini-1000de") == 0)
 		{
+			free(boxtype_name);
 			boxtype_name = ReadProcEntry("/proc/stb/fp/version");
 			if(startsWith(boxtype_name, "2"))
 			{
+				free(boxtype_name);
 				return "xpeedlx2";
 			}
 			else
 			{
+				free(boxtype_name);
 				return "xpeedlx1";
 			}
 		}
-	}  
+	}
 	else if(strcmp(BOXTYPE, "ventonhdx") == 0)
 	{
 		boxtype_name = ReadProcEntry("/proc/stb/info/boxtype");
-		if(strcmp(boxtype_name, "ini-3000") == 0) 
+		if(strcmp(boxtype_name, "ini-3000") == 0)
 		{
+			free(boxtype_name);
 			return "uniboxhd1";
 		}
-		else if(strcmp(boxtype_name, "ini-5000") == 0) 
+		else if(strcmp(boxtype_name, "ini-5000") == 0)
 		{
+			free(boxtype_name);
 			return "uniboxhd2";
 		}
-		else if(strcmp(boxtype_name, "ini-7000") == 0) 
+		else if(strcmp(boxtype_name, "ini-7000") == 0)
 		{
+			free(boxtype_name);
 			return "uniboxhd3";
 		}
-		else if(strcmp(boxtype_name, "ini-7012") == 0) 
+		else if(strcmp(boxtype_name, "ini-7012") == 0)
 		{
+			free(boxtype_name);
 			return "uniboxhd3";
 		}
 	}
 	else if(strcmp(BOXTYPE, "et6x00") == 0 || strcmp(BOXTYPE, "et9x00") == 0 || strcmp(BOXTYPE, "et7x00") == 0)
 	{
 		boxtype_name = ReadProcEntry("/proc/stb/info/boxtype");
+		// TODO: Change API so that caller must free() the string, otherwise this will leak the memory allocated in ReadProcEntry.
 		return boxtype_name;
 	}
 	else
 	{
-		return BOXTYPE;  
+		return BOXTYPE;
 	}
 }
 
@@ -134,112 +154,137 @@ const char *_getMachineName()
 	{
 		boxtype_name = ReadProcEntry("/proc/stb/info/boxtype");
 		/** INI DETECTION */
-		if(strcmp(boxtype_name, "ini-3000") == 0) 
+		if(strcmp(boxtype_name, "ini-3000") == 0)
 		{
+			free(boxtype_name);
 			return "HD-1";
 		}
-		else if(strcmp(boxtype_name, "ini-5000") == 0) 
+		else if(strcmp(boxtype_name, "ini-5000") == 0)
 		{
+			free(boxtype_name);
 			return "HD-2";
 		}
-		else if(strcmp(boxtype_name, "ini-7000") == 0) 
+		else if(strcmp(boxtype_name, "ini-7000") == 0)
 		{
+			free(boxtype_name);
 			return "HD-3";
 		}
-		else if(strcmp(boxtype_name, "ini-7012") == 0) 
+		else if(strcmp(boxtype_name, "ini-7012") == 0)
 		{
+			free(boxtype_name);
 			return "HD-3";
 		}
-		else if(strcmp(boxtype_name, "ini-1000lx") == 0) 
+		else if(strcmp(boxtype_name, "ini-1000lx") == 0)
 		{
+			free(boxtype_name);
 			return "LX-2T";
 		}
 		/** XTREND DETECTION */
-		else if(strcmp(boxtype_name, "et4x00") == 0) 
+		else if(strcmp(boxtype_name, "et4x00") == 0)
 		{
+			free(boxtype_name);
 			return "ET4x00";
 		}
-		else if(strcmp(boxtype_name, "et4000") == 0) 
+		else if(strcmp(boxtype_name, "et4000") == 0)
 		{
+			free(boxtype_name);
 			return "ET4000";
 		}
-		else if(strcmp(boxtype_name, "et5x00") == 0) 
+		else if(strcmp(boxtype_name, "et5x00") == 0)
 		{
+			free(boxtype_name);
 			return "ET5x00";
 		}
-		else if(strcmp(boxtype_name, "et5000") == 0) 
+		else if(strcmp(boxtype_name, "et5000") == 0)
 		{
+			free(boxtype_name);
 			return "ET5000";
-		}		
-		else if(strcmp(boxtype_name, "et6000") == 0) 
+		}
+		else if(strcmp(boxtype_name, "et6000") == 0)
 		{
+			free(boxtype_name);
 			return "ET6000";
 		}
-		else if(strcmp(boxtype_name, "et6500") == 0) 
+		else if(strcmp(boxtype_name, "et6500") == 0)
 		{
+			free(boxtype_name);
 			return "ET6500";
 		}
-		else if(strcmp(boxtype_name, "et7000") == 0) 
+		else if(strcmp(boxtype_name, "et7000") == 0)
 		{
+			free(boxtype_name);
 			return "ET7000";
 		}
-		else if(strcmp(boxtype_name, "et7500") == 0) 
+		else if(strcmp(boxtype_name, "et7500") == 0)
 		{
+			free(boxtype_name);
 			return "ET7500";
 		}
-		else if(strcmp(boxtype_name, "et9x00") == 0) 
+		else if(strcmp(boxtype_name, "et9x00") == 0)
 		{
+			free(boxtype_name);
 			return "ET9x00";
 		}
-		else if(strcmp(boxtype_name, "et9000") == 0) 
+		else if(strcmp(boxtype_name, "et9000") == 0)
 		{
+			free(boxtype_name);
 			return "ET9000";
 		}
-		else if(strcmp(boxtype_name, "et9200") == 0) 
+		else if(strcmp(boxtype_name, "et9200") == 0)
 		{
+			free(boxtype_name);
 			return "ET9200";
 		}
-		else if(strcmp(boxtype_name, "et9500") == 0) 
+		else if(strcmp(boxtype_name, "et9500") == 0)
 		{
+			free(boxtype_name);
 			return "ET9500";
 		}
 		else /** if there is not matching STB name, return value from proc */
 		{
+			free(boxtype_name);
 			return MACHINE_NAME;
 		}
 	}
 	/** AzBOX DETECTION */
 	else if(fileExist("/proc/stb/info/azmodel"))
-	{	
+	{
 		if(fileExist("/proc/stb/info/model"))
 		{
 			boxtype_name = ReadProcEntry("/proc/stb/info/model");
-			if(strcmp(boxtype_name, "me") == 0) 
+			if(strcmp(boxtype_name, "me") == 0)
 			{
+				free(boxtype_name);
 				return "Me";
 			}
-			else if(strcmp(boxtype_name, "minime") == 0) 
+			else if(strcmp(boxtype_name, "minime") == 0)
 			{
+				free(boxtype_name);
 				return "Mini Me";
 			}
-			else if(strcmp(boxtype_name, "premium") == 0) 
+			else if(strcmp(boxtype_name, "premium") == 0)
 			{
+				free(boxtype_name);
 				return "Premium";
 			}
-			else if(strcmp(boxtype_name, "premium+") == 0) 
+			else if(strcmp(boxtype_name, "premium+") == 0)
 			{
+				free(boxtype_name);
 				return "Premium+";
 			}
-			else if(strcmp(boxtype_name, "elite") == 0) 
+			else if(strcmp(boxtype_name, "elite") == 0)
 			{
+				free(boxtype_name);
 				return "Elite";
 			}
-			else if(strcmp(boxtype_name, "ultra") == 0) 
+			else if(strcmp(boxtype_name, "ultra") == 0)
 			{
+				free(boxtype_name);
 				return "Ultra";
 			}
 			else
 			{
+				free(boxtype_name);
 				return MACHINE_NAME;
 			}
 		}
@@ -257,13 +302,13 @@ const char *_getMachineName()
 const char *_getMachineBrand()
 {
 	char *boxtype_name = NULL;
-	
+
 	return MACHINE_BRAND;
 }
 
 const char *_getBrandOEM()
 {
-	return BRAND_OEM;  
+	return BRAND_OEM;
 }
 
 const char *_getDriverDate()
@@ -272,26 +317,26 @@ const char *_getDriverDate()
 	int len = 0;
 	char *real_driver_date = NULL;
 	char driver_date[30];
-	
+
 	/** INI has in each driver build date - NO NEEED TAKE IT FROM BB FILE*/
-	if((driver_file = fopen("/proc/stb/info/boxtype", "r")) != NULL) 
+	if((driver_file = fopen("/proc/stb/info/boxtype", "r")) != NULL)
 	{
 		fgets(driver_date, sizeof(driver_date), driver_file);
 		fclose(driver_file);
-		
+
 		if(startsWith(driver_date, "ini"))
 		{
 			if((driver_file = fopen("/proc/stb/info/version", "r")) != NULL)
 			{
 				fgets(driver_date, sizeof(driver_date), driver_file);
 				fclose(driver_file);
-				
+
 				real_driver_date = malloc(strlen(driver_date) + 1);
 				if (real_driver_date)
 					strcpy(real_driver_date, driver_date);
 				len = strlen(real_driver_date);
 				if (len > 0 && real_driver_date[len - 1 ] == '\n')
-					real_driver_date[len - 1] = '\0';                                
+					real_driver_date[len - 1] = '\0';
 				return real_driver_date;
 			}
 			else
@@ -309,18 +354,18 @@ const char *_getDriverDate()
 	{
 		fgets(driver_date, sizeof(driver_date), driver_file);
 		fclose(driver_file);
-		
+
 		if((driver_file = fopen("/proc/stb/info/buildate", "r")) != NULL)
 		{
 			fgets(driver_date, sizeof(driver_date), driver_file);
 			fclose(driver_file);
-			
+
 			real_driver_date = malloc(strlen(driver_date) + 1);
 			if (real_driver_date)
 				strcpy(real_driver_date, driver_date);
 			len = strlen(real_driver_date);
 			if (len > 0 && real_driver_date[len - 1 ] == '\n')
-				real_driver_date[len - 1] = '\0';                                
+				real_driver_date[len - 1] = '\0';
 			return real_driver_date;
 		}
 		else
@@ -329,8 +374,8 @@ const char *_getDriverDate()
 		}
 	}
 	else
-	{  
-		return DRIVERDATE;  
+	{
+		return DRIVERDATE;
 	}
 }
 
@@ -366,7 +411,7 @@ const char *_getImageFileSystem()
 
 const char *_getOEVersion()
 {
-	return OE_VER;  
+	return OE_VER;
 }
 
 const char *_getMachineBuild()
@@ -418,37 +463,37 @@ const char *_getMachineProcModel() // return just value from proc entry
 	char *real_boxtype_name = NULL;
 	char *vu_boxtype_name = NULL;
 	int len;
-	
+
 	if((boxtype_file = fopen("/proc/stb/info/hwmodel", "r")) != NULL)
 	{
 		fgets(boxtype_name, sizeof(boxtype_name), boxtype_file);
 		fclose(boxtype_file);
-		
+
 		real_boxtype_name = malloc(strlen(boxtype_name) + 1);
 		if (real_boxtype_name)
 			strcpy(real_boxtype_name, boxtype_name);
 		len = strlen(real_boxtype_name);
 		if (len > 0 && real_boxtype_name[len - 1 ] == '\n')
-			real_boxtype_name[len - 1] = '\0';                                
+			real_boxtype_name[len - 1] = '\0';
 		return real_boxtype_name;
 	}
 	else if((boxtype_file = fopen("/proc/stb/info/boxtype", "r")) != NULL)
 	{
 		fgets(boxtype_name, sizeof(boxtype_name), boxtype_file);
 		fclose(boxtype_file);
-		
+
 		if(strcmp(boxtype_name, "gigablue\n") == 0)
 		{
 			if((boxtype_file = fopen("/proc/stb/info/boxtype", "r")) != NULL)
 			{
 				fgets(boxtype_name, sizeof(boxtype_name), boxtype_file);
-				fclose(boxtype_file); 
-				
+				fclose(boxtype_file);
+
 				if((boxtype_file = fopen("/proc/stb/info/gbmodel", "r")) != NULL)
 				{
 					fgets(boxtype_name, sizeof(boxtype_name), boxtype_file);
-					fclose(boxtype_file);  
-					
+					fclose(boxtype_file);
+
 				}
 			}
 		}
@@ -457,26 +502,26 @@ const char *_getMachineProcModel() // return just value from proc entry
 			strcpy(real_boxtype_name, boxtype_name);
 		len = strlen(real_boxtype_name);
 		if (len > 0 && real_boxtype_name[len - 1 ] == '\n')
-			real_boxtype_name[len - 1] = '\0';                                
+			real_boxtype_name[len - 1] = '\0';
 		return real_boxtype_name;
 	}
 	/** AzBOX DETECTION */
 	else if((boxtype_file = fopen("/proc/stb/info/azmodel", "r")) != NULL)
 	{
 		fgets(boxtype_name, sizeof(boxtype_name), boxtype_file);
-		fclose(boxtype_file); 
-		
+		fclose(boxtype_file);
+
 		if((boxtype_file = fopen("/proc/stb/info/model", "r")) != NULL)
 		{
 			fgets(boxtype_name, sizeof(boxtype_name), boxtype_file);
-			fclose(boxtype_file); 
-			
+			fclose(boxtype_file);
+
 			real_boxtype_name = malloc(strlen(boxtype_name) + 1);
 			if (real_boxtype_name)
 				strcpy(real_boxtype_name, boxtype_name);
 			len = strlen(real_boxtype_name);
 			if (len > 0 && real_boxtype_name[len - 1 ] == '\n')
-				real_boxtype_name[len - 1] = '\0';                                
+				real_boxtype_name[len - 1] = '\0';
 			return real_boxtype_name;
 		}
 		else
@@ -489,16 +534,16 @@ const char *_getMachineProcModel() // return just value from proc entry
 	{
 		fgets(boxtype_name, sizeof(boxtype_name), boxtype_file);
 		fclose(boxtype_file);
-		
+
 		real_boxtype_name = malloc(strlen(boxtype_name) + 1);
 		if (real_boxtype_name)
 			strcpy(real_boxtype_name, boxtype_name);
 		len = strlen(real_boxtype_name);
 		if (len > 0 && real_boxtype_name[len - 1 ] == '\n')
-			real_boxtype_name[len - 1] = '\0';    
-		
+			real_boxtype_name[len - 1] = '\0';
+
 		sprintf(real_boxtype_name, "vu%s", boxtype_name);
-		
+
 		vu_boxtype_name = malloc(strlen(real_boxtype_name) + 1);
 		if (vu_boxtype_name)
 			strcpy(vu_boxtype_name, real_boxtype_name);
@@ -513,18 +558,18 @@ const char *_getMachineProcModel() // return just value from proc entry
 		if((boxtype_file = fopen("/proc/stb/info/model", "r")) != NULL)
 		{
 			fgets(boxtype_name, sizeof(boxtype_name), boxtype_file);
-			fclose(boxtype_file); 
+			fclose(boxtype_file);
 			real_boxtype_name = malloc(strlen(boxtype_name) + 1);
 			if (real_boxtype_name)
 				strcpy(real_boxtype_name, boxtype_name);
 			len = strlen(real_boxtype_name);
 			if (len > 0 && real_boxtype_name[len - 1 ] == '\n')
-				real_boxtype_name[len - 1] = '\0';                                
+				real_boxtype_name[len - 1] = '\0';
 			return real_boxtype_name;
 		}
 		else
 		{
 			return MACHINE_NAME;
 		}
-	}  
+	}
 }

--- a/BoxBranding/lib/boxbranding.h
+++ b/BoxBranding/lib/boxbranding.h
@@ -2,30 +2,34 @@
 #define __BRANDING_H__
 
 bool startsWith (char* base, char* str);
-bool endsWith (char* base, char* str); 
+bool endsWith (char* base, char* str);
 int fileExist(const char* filename);
-char* ReadProcEntry(char *filename);
 
-const char *_getBoxType();
-const char *_getMachineName();
-const char *_getMachineBrand();
-const char *_getBrandOEM();
-const char *_getDriverDate();
-const char *_getImageVersion();
-const char *_getImageBuild();
-const char *_getImageType();
-const char *_getImageDistro();
-const char *_getImageFolder();
-const char *_getImageFileSystem();
-const char *_getOEVersion();
-const char *_getMachineBuild();
-const char *_getMachineMake();
-const char *_getMachineMtdRoot();
-const char *_getMachineRootFile();
-const char *_getMachineMtdKernel();
-const char *_getMachineKernelFile();
-const char *_getMachineMKUBIFS();
-const char *_getMachineUBINIZE();
-const char *_getMachineProcModel();
+/* The caller is always responsible for calling free() on the returned
+ * string from all the functions that follow. */
+
+char *ReadProcEntry(char *filename);
+
+char *_getBoxType();
+char *_getMachineName();
+char *_getMachineBrand();
+char *_getBrandOEM();
+char *_getDriverDate();
+char *_getImageVersion();
+char *_getImageBuild();
+char *_getImageType();
+char *_getImageDistro();
+char *_getImageFolder();
+char *_getImageFileSystem();
+char *_getOEVersion();
+char *_getMachineBuild();
+char *_getMachineMake();
+char *_getMachineMtdRoot();
+char *_getMachineRootFile();
+char *_getMachineMtdKernel();
+char *_getMachineKernelFile();
+char *_getMachineMKUBIFS();
+char *_getMachineUBINIZE();
+char *_getMachineProcModel();
 
 #endif

--- a/BoxBranding/remotes/Makefile.am
+++ b/BoxBranding/remotes/Makefile.am
@@ -1,3 +1,5 @@
+SUBDIRS =
+
 if S7100
 SUBDIRS = red1
 endif
@@ -187,39 +189,39 @@ SUBDIRS = tm3
 endif
 
 if VENTON
-SUBDIRS = ini0 ini1 ini2
+SUBDIRS += ini0 ini1 ini2
 endif
 
 if INI
-SUBDIRS = ini0 ini1 ini2 ini3 ini4 ini5 ini6 ini7 ini8
+SUBDIRS += ini0 ini1 ini2 ini3 ini4 ini5 ini6 ini7 ini8
 endif
 
 if MIRACLEBOX
-SUBDIRS = ini3
+SUBDIRS += ini3
 endif
 
 if XPEED
-SUBDIRS = ini4 gi1
+SUBDIRS += ini4 gi1
 endif
 
 if SEZAM
-SUBDIRS = ini2 ini4
+SUBDIRS += ini2 ini4
 endif
 
 if ATEMIO
-SUBDIRS = ini4
+SUBDIRS += ini4
 endif
 
 if BEYONWIZ
-SUBDIRS = ini5 ini7
+SUBDIRS += ini5 ini7
 endif
 
 if BWIDOW
-SUBDIRS = ini6
+SUBDIRS += ini6
 endif
 
 if FEGASUS
-SUBDIRS = ini6
+SUBDIRS += ini6
 endif
 
 if VUSOLO

--- a/BoxBranding/remotes/Makefile.am
+++ b/BoxBranding/remotes/Makefile.am
@@ -191,7 +191,7 @@ SUBDIRS = ini0 ini1 ini2
 endif
 
 if INI
-SUBDIRS = ini0 ini1 ini2 ini3 ini4 ini5 ini6 ini8
+SUBDIRS = ini0 ini1 ini2 ini3 ini4 ini5 ini6 ini7 ini8
 endif
 
 if MIRACLEBOX


### PR DESCRIPTION
* The C API for returning strings now allocates memory for the string
  and it is the responsibility of the caller to call free() on the
  string when it is no longer needed. This API change was required to
  avoid memory leaks.

* The Python wrapper had numerous issues that caused compiler warnings.
  These are now fixed by using the correct types and the appropriate
  number of arguments. The wrapper code has also been updated to call
  free() on returned strings as detailed above and the code was
  simplified by using a macro to replicate the boilerplate code.

* Some unused variables were removed.

* There was a buffer overrun in the Vu+ code. This was replaced with a
  simpler implementation that now allocates a buffer big enough for the
  required string.

* A number of non-void functions had code paths without a return.

* Added a comment about a discrepancy between code and comments. One of
  these will need to be corrected later.