### PR TITLE
Set the correct remote type for an MBtwin - used by OpenWebIF.

### DIFF
--- a/BoxBranding/RcModel.py
+++ b/BoxBranding/RcModel.py
@@ -157,6 +157,8 @@ class RcModel:
 		elif machinebrand == 'Miraclebox':
 			if boxtype in ('mbmicro', 'mbmicrov2', 'mbtwinplus'):
 				remotefolder = 'miraclebox'
+			elif boxtype == 'mbtwin':
+				remotefolder = 'ini4'
 			else:
 				remotefolder = 'ini3'
 		elif boxtype in ('xpeedlx', 'xpeedlx1', 'xpeedlx2', 'xpeedlx3', 'atemio5x00', 'atemio6000', 'atemio6100', 'atemio6200', 'atemionemesis', 'sezammarvel'):


### PR DESCRIPTION
The mbtwin remote sends the codes for an ini4 remote, not an ini3.
If you look at the keys defined in the remote.html file you'll actually see that the ini4 defines things like "fav", "web" and "pip" all of which are on the remote - the ini3 does not defined these keys.
It also has a "media" key that sends 226, not a "filelist" one sending 395.
Oddly, the ini3 image layout is the same as the ini4 one, even though the ini3 remote.html defines fewer, and different, keys.
It's possible that all Miracleboxes use ini4 not ini3 - I can only test the mbtwin (and have done so).