### PR TITLE
Correct two key definitions in et8000 for OpenWebIF.

### DIFF
--- a/BoxBranding/remotes/et8000/remote.html
+++ b/BoxBranding/remotes/et8000/remote.html
@@ -44,8 +44,8 @@
 	<area shape="rect" coords="20,322,44,334" alt="F1" onclick="pressMenuRemote('59');">
 	<area shape="rect" coords="49,322,72,334" alt="F2" onclick="pressMenuRemote('60');">
 	<area shape="rect" coords="78,322,101,334" alt="F3" onclick="pressMenuRemote('61');">
-	<area shape="rect" coords="20,341,44,354" alt="Timeshift" onclick="pressMenuRemote('119');">
-	<area shape="rect" coords="49,341,72,354" alt="List" onclick="pressMenuRemote('393');">
+	<area shape="rect" coords="20,341,44,354" alt="Timeshift" onclick="pressMenuRemote('359');">
+	<area shape="rect" coords="49,341,72,354" alt="List" onclick="pressMenuRemote('144');">
 	<area shape="rect" coords="78,341,101,354" alt="HDMI Rx" onclick="pressMenuRemote('390');">
 	<area shape="rect" coords="20,359,44,373" alt="Timer" onclick="pressMenuRemote('362');">
 	<area shape="rect" coords="49,359,72,373" alt="PIP" onclick="pressMenuRemote('375');">


### PR DESCRIPTION
I've tested the keycodes actually sent by the remote for an et8000 by looking at the debug log report for each keypress.
Two of them are incorrect in the current configuration file.
The Timeshift key actually sends 359 (not 119) and the List key sends 144 (not 393).
This fixes these codes for the OpenWebIF interface remote keying.