### PR TITLE
Beyonwiz remote fixups

### DIFF
--- a/BoxBranding/remotes/beyonwiz1/remote.html
+++ b/BoxBranding/remotes/beyonwiz1/remote.html
@@ -1,56 +1,56 @@
 <img border="0" src="static/remotes/beyonwiz1/rc.png" usemap="#map" >
 <map name="map">
-<area shape="circle" coords="37,39,9" alt="Power" onclick="pressMenuRemote('116');">
-<area shape="rect" coords="86,33,102,45" alt="wiztv" onclick="pressMenuRemote('390');">
-<area shape="rect" coords="45,57,59,67" alt="tv/radio" onclick="pressMenuRemote('377');">
-<area shape="rect" coords="71,57,85,67" alt="video mode" onclick="pressMenuRemote('227');">
-<area shape="circle" coords="21,84,8" alt="autotimer" onclick="pressMenuRemote('397');">
-<area shape="rect" coords="42,78,58,90" alt="timer" onclick="pressMenuRemote('362');">
-<area shape="rect" coords="73,78,89,90" alt="fav" onclick="pressMenuRemote('364');">
-<area shape="circle" coords="110,84,8" alt="epg" onclick="pressMenuRemote('365');">
-<area shape="rect" coords="33,107,45,119" alt="volume up" onclick="pressMenuRemote('115');">
-<area shape="circle" coords="65,113,8" alt="mute" onclick="pressMenuRemote('113');">
-<area shape="rect" coords="85,107,97,119" alt="channel up" onclick="pressMenuRemote('402');">
-<area shape="rect" coords="33,131,45,143" alt="volume down" onclick="pressMenuRemote('114');">
-<area shape="circle" coords="65,137,8" alt="info" onclick="pressMenuRemote('358');">
-<area shape="rect" coords="85,131,97,143" alt="channel down" onclick="pressMenuRemote('403');">
-<area shape="circle" coords="21,166,8" alt="back" onclick="pressMenuRemote('405');">
-<area shape="rect" coords="42,160,58,172" alt="stop" onclick="pressMenuRemote('128');">
-<area shape="rect" coords="73,160,89,172" alt="playpause" onclick="pressMenuRemote('164');">
-<area shape="circle" coords="110,166,8" alt="media" onclick="pressMenuRemote('226');">
-<area shape="rect" coords="52,186,78,200" alt="up" onclick="pressMenuRemote('103');">
-<area shape="rect" coords="14,204,26,226" alt="exit" onclick="pressMenuRemote('174');">
-<area shape="rect" coords="35,202,49,228" alt="left" onclick="pressMenuRemote('105');">
-<area shape="rect" coords="57,207,73,223" alt="ok" onclick="pressMenuRemote('352');">
-<area shape="rect" coords="81,202,95,228" alt="right" onclick="pressMenuRemote('106');">
-<area shape="rect" coords="104,204,116,226" alt="menu" onclick="pressMenuRemote('139');">
-<area shape="rect" coords="52,231,78,245" alt="down" onclick="pressMenuRemote('108');">
-<area shape="circle" coords="22,267,8" alt="red" onclick="pressMenuRemote('398');">
-<area shape="circle" coords="51,267,8" alt="green" onclick="pressMenuRemote('399');">
-<area shape="circle" coords="79,267,8" alt="yellow" onclick="pressMenuRemote('400');">
-<area shape="circle" coords="108,267,8" alt="blue" onclick="pressMenuRemote('401');">
-<area shape="rect" coords="23,283,39,295" alt="1" onclick="pressMenuRemote('2');">
-<area shape="rect" coords="58,283,74,295" alt="2" onclick="pressMenuRemote('3');">
-<area shape="rect" coords="93,283,109,295" alt="3" onclick="pressMenuRemote('4');">
-<area shape="rect" coords="23,300,39,312" alt="4" onclick="pressMenuRemote('5');">
-<area shape="rect" coords="58,300,74,312" alt="5" onclick="pressMenuRemote('6');">
-<area shape="rect" coords="93,300,109,312" alt="6" onclick="pressMenuRemote('7');">
-<area shape="rect" coords="23,317,39,329" alt="7" onclick="pressMenuRemote('8');">
-<area shape="rect" coords="58,317,74,329" alt="8" onclick="pressMenuRemote('9');">
-<area shape="rect" coords="93,317,109,329" alt="9" onclick="pressMenuRemote('10');">
-<area shape="rect" coords="23,335,39,347" alt="previous" onclick="pressMenuRemote('412');">
-<area shape="rect" coords="58,335,74,347" alt="0" onclick="pressMenuRemote('11');">
-<area shape="rect" coords="93,335,109,347" alt="next" onclick="pressMenuRemote('407');">
-<area shape="rect" coords="21,360,35,370" alt="rewind" onclick="pressMenuRemote('168');">
-<area shape="rect" coords="46,360,60,370" alt="record" onclick="pressMenuRemote('167');">
-<area shape="rect" coords="71,360,85,370" alt="slow" onclick="pressMenuRemote('409');">
-<area shape="rect" coords="96,360,110,370" alt="forward" onclick="pressMenuRemote('208');">
-<area shape="rect" coords="21,378,35,388" alt="plugin" onclick="pressMenuRemote('156');">
-<area shape="rect" coords="46,378,60,388" alt="sleep" onclick="pressMenuRemote('142');">
-<area shape="rect" coords="71,378,85,388" alt="about" onclick="pressMenuRemote('214');">
-<area shape="rect" coords="96,378,110,388" alt="setup" onclick="pressMenuRemote('141');">
-<area shape="circle" coords="28,401,7" alt="subtitle" onclick="pressMenuRemote('370');">
-<area shape="circle" coords="53,401,7" alt="audio" onclick="pressMenuRemote('392');">
-<area shape="circle" coords="78,401,7" alt="text" onclick="pressMenuRemote('388');">
-<area shape="circle" coords="103,401,7" alt="help" onclick="pressMenuRemote('138');">
+<area shape="circle" coords="37,39,9" title="Power" onclick="pressMenuRemote('116');">
+<area shape="rect" coords="86,33,102,45" title="wiztv" onclick="pressMenuRemote('390');">
+<area shape="rect" coords="45,57,59,67" title="tv/radio" onclick="pressMenuRemote('377');">
+<area shape="rect" coords="71,57,85,67" title="video mode" onclick="pressMenuRemote('227');">
+<area shape="circle" coords="21,84,8" title="autotimer" onclick="pressMenuRemote('397');">
+<area shape="rect" coords="42,78,58,90" title="timer" onclick="pressMenuRemote('362');">
+<area shape="rect" coords="73,78,89,90" title="fav" onclick="pressMenuRemote('364');">
+<area shape="circle" coords="110,84,8" title="epg" onclick="pressMenuRemote('365');">
+<area shape="rect" coords="33,107,45,119" title="volume up" onclick="pressMenuRemote('115');">
+<area shape="circle" coords="65,113,8" title="mute" onclick="pressMenuRemote('113');">
+<area shape="rect" coords="85,107,97,119" title="channel up" onclick="pressMenuRemote('402');">
+<area shape="rect" coords="33,131,45,143" title="volume down" onclick="pressMenuRemote('114');">
+<area shape="circle" coords="65,137,8" title="info" onclick="pressMenuRemote('358');">
+<area shape="rect" coords="85,131,97,143" title="channel down" onclick="pressMenuRemote('403');">
+<area shape="circle" coords="21,166,8" title="back" onclick="pressMenuRemote('405');">
+<area shape="rect" coords="42,160,58,172" title="stop" onclick="pressMenuRemote('128');">
+<area shape="rect" coords="73,160,89,172" title="playpause" onclick="pressMenuRemote('164');">
+<area shape="circle" coords="110,166,8" title="media" onclick="pressMenuRemote('226');">
+<area shape="rect" coords="52,186,78,200" title="up" onclick="pressMenuRemote('103');">
+<area shape="rect" coords="14,204,26,226" title="exit" onclick="pressMenuRemote('174');">
+<area shape="rect" coords="35,202,49,228" title="left" onclick="pressMenuRemote('105');">
+<area shape="rect" coords="57,207,73,223" title="ok" onclick="pressMenuRemote('352');">
+<area shape="rect" coords="81,202,95,228" title="right" onclick="pressMenuRemote('106');">
+<area shape="rect" coords="104,204,116,226" title="menu" onclick="pressMenuRemote('139');">
+<area shape="rect" coords="52,231,78,245" title="down" onclick="pressMenuRemote('108');">
+<area shape="circle" coords="22,267,8" title="red" onclick="pressMenuRemote('398');">
+<area shape="circle" coords="51,267,8" title="green" onclick="pressMenuRemote('399');">
+<area shape="circle" coords="79,267,8" title="yellow" onclick="pressMenuRemote('400');">
+<area shape="circle" coords="108,267,8" title="blue" onclick="pressMenuRemote('401');">
+<area shape="rect" coords="23,283,39,295" title="1" onclick="pressMenuRemote('2');">
+<area shape="rect" coords="58,283,74,295" title="2" onclick="pressMenuRemote('3');">
+<area shape="rect" coords="93,283,109,295" title="3" onclick="pressMenuRemote('4');">
+<area shape="rect" coords="23,300,39,312" title="4" onclick="pressMenuRemote('5');">
+<area shape="rect" coords="58,300,74,312" title="5" onclick="pressMenuRemote('6');">
+<area shape="rect" coords="93,300,109,312" title="6" onclick="pressMenuRemote('7');">
+<area shape="rect" coords="23,317,39,329" title="7" onclick="pressMenuRemote('8');">
+<area shape="rect" coords="58,317,74,329" title="8" onclick="pressMenuRemote('9');">
+<area shape="rect" coords="93,317,109,329" title="9" onclick="pressMenuRemote('10');">
+<area shape="rect" coords="23,335,39,347" title="previous" onclick="pressMenuRemote('412');">
+<area shape="rect" coords="58,335,74,347" title="0" onclick="pressMenuRemote('11');">
+<area shape="rect" coords="93,335,109,347" title="next" onclick="pressMenuRemote('407');">
+<area shape="rect" coords="21,360,35,370" title="rewind" onclick="pressMenuRemote('168');">
+<area shape="rect" coords="46,360,60,370" title="record" onclick="pressMenuRemote('167');">
+<area shape="rect" coords="71,360,85,370" title="slow" onclick="pressMenuRemote('409');">
+<area shape="rect" coords="96,360,110,370" title="forward" onclick="pressMenuRemote('208');">
+<area shape="rect" coords="21,378,35,388" title="plugin" onclick="pressMenuRemote('156');">
+<area shape="rect" coords="46,378,60,388" title="sleep" onclick="pressMenuRemote('142');">
+<area shape="rect" coords="71,378,85,388" title="about" onclick="pressMenuRemote('214');">
+<area shape="rect" coords="96,378,110,388" title="setup" onclick="pressMenuRemote('141');">
+<area shape="circle" coords="28,401,7" title="subtitle" onclick="pressMenuRemote('370');">
+<area shape="circle" coords="53,401,7" title="audio" onclick="pressMenuRemote('392');">
+<area shape="circle" coords="78,401,7" title="text" onclick="pressMenuRemote('388');">
+<area shape="circle" coords="103,401,7" title="help" onclick="pressMenuRemote('138');">
 </map>

--- a/BoxBranding/remotes/beyonwiz1/remote.html
+++ b/BoxBranding/remotes/beyonwiz1/remote.html
@@ -1,4 +1,4 @@
-<img border="0" src="static/remotes/beyonwiz1/rc.png" usemap="#map" >
+<img border="0" src="/static/remotes/beyonwiz1/rc.png" usemap="#map" >
 <map name="map">
 <area shape="circle" coords="37,39,9" title="Power" onclick="pressMenuRemote('116');">
 <area shape="rect" coords="86,33,102,45" title="wiztv" onclick="pressMenuRemote('390');">

--- a/BoxBranding/remotes/beyonwiz2/remote.html
+++ b/BoxBranding/remotes/beyonwiz2/remote.html
@@ -1,4 +1,4 @@
-<img border="0" src="static/remotes/beyonwiz2/rc.png" usemap="#map" >
+<img border="0" src="/static/remotes/beyonwiz2/rc.png" usemap="#map" >
 <map name="map">
 <area shape="circle" coords="25,60,10" id="116" title="Power" onclick="pressMenuRemote('116');">
 <area shape="circle" coords="95,60,10" id="113" title="mute" onclick="pressMenuRemote('113');">

--- a/BoxBranding/remotes/beyonwiz2/remote.html
+++ b/BoxBranding/remotes/beyonwiz2/remote.html
@@ -1,53 +1,53 @@
 <img border="0" src="static/remotes/beyonwiz2/rc.png" usemap="#map" >
 <map name="map">
-<area shape="circle" coords="25,60,10" id="116" alt="Power" onclick="pressMenuRemote('116');">
-<area shape="circle" coords="95,60,10" id="113" alt="mute" onclick="pressMenuRemote('113');">
-<area shape="rect" coords="12,76,28,92" id="362" alt="timer" onclick="pressMenuRemote('362');">
-<area shape="rect" coords="40,76,56,92" id="377" alt="tv/radio" onclick="pressMenuRemote('377');">
-<area shape="rect" coords="67,76,83,92" id="227" alt="video mode" onclick="pressMenuRemote('227');">
-<area shape="rect" coords="67,76,83,92" id="227" alt="video mode" onclick="pressMenuRemote('227');">
-<area shape="rect" coords="95,76,111,92" id="364" alt="fav" onclick="pressMenuRemote('364');">
-<area shape="rect" coords="11,99,37,111" id="2" alt="1" onclick="pressMenuRemote('2');">
-<area shape="rect" coords="49,99,75,111" id="3" alt="2" onclick="pressMenuRemote('3');">
-<area shape="rect" coords="87,99,113,111" id="4" alt="3" onclick="pressMenuRemote('4');">
-<area shape="rect" coords="11,118,37,130" id="5" alt="4" onclick="pressMenuRemote('5');">
-<area shape="rect" coords="49,118,75,130" id="6" alt="5" onclick="pressMenuRemote('6');">
-<area shape="rect" coords="87,118,113,130" id="7" alt="6" onclick="pressMenuRemote('7');">
-<area shape="rect" coords="11,138,37,150" id="8" alt="7" onclick="pressMenuRemote('8');">
-<area shape="rect" coords="49,138,75,150" id="9" alt="8" onclick="pressMenuRemote('9');">
-<area shape="rect" coords="87,138,113,150" id="10" alt="9" onclick="pressMenuRemote('10');">
-<area shape="rect" coords="11,157,37,169" id="412" alt="previous" onclick="pressMenuRemote('412');">
-<area shape="rect" coords="49,157,75,169" id="11" alt="0" onclick="pressMenuRemote('11');">
-<area shape="rect" coords="87,157,113,169" id="407" alt="next" onclick="pressMenuRemote('407');">
-<area shape="rect" coords="51,181,73,203" id="226" alt="media" onclick="pressMenuRemote('226');">
-<area shape="rect" coords="11,180,35,208" id="115" alt="volume up" onclick="pressMenuRemote('115');">
-<area shape="rect" coords="89,180,113,208" id="402" alt="channel up" onclick="pressMenuRemote('402');">
-<area shape="rect" coords="11,210,35,238" id="114" alt="volume down" onclick="pressMenuRemote('114');">
-<area shape="rect" coords="89,210,113,238" id="403" alt="channel down" onclick="pressMenuRemote('403');">
-<area shape="rect" coords="51,215,73,237" id="365" alt="epg" onclick="pressMenuRemote('365');">
-<area shape="circle" coords="24,258,12" id="174" alt="exit" onclick="pressMenuRemote('174');">
-<area shape="circle" coords="100,258,12" id="139" alt="menu" onclick="pressMenuRemote('139');">
-<area shape="circle" coords="62,262,12" id="103" alt="up" onclick="pressMenuRemote('103');">
-<area shape="circle" coords="25,296,12" id="105" alt="left" onclick="pressMenuRemote('105');">
-<area shape="circle" coords="62,296,18" id="352" alt="ok" onclick="pressMenuRemote('352');">
-<area shape="circle" coords="99,296,12" id="106" alt="right" onclick="pressMenuRemote('106');">
-<area shape="circle" coords="62,333,12" id="108" alt="down" onclick="pressMenuRemote('108');">
-<area shape="circle" coords="24,334,12" id="405" alt="back" onclick="pressMenuRemote('405');">
-<area shape="circle" coords="100,334,12" id="358" alt="info" onclick="pressMenuRemote('358');">
-<area shape="rect" coords="12,353,28,369" id="398" alt="red" onclick="pressMenuRemote('398');">
-<area shape="rect" coords="40,353,56,369" id="399" alt="green" onclick="pressMenuRemote('399');">
-<area shape="rect" coords="67,353,83,369" id="400" alt="yellow" onclick="pressMenuRemote('400');">
-<area shape="rect" coords="95,353,111,369" id="401" alt="blue" onclick="pressMenuRemote('401');">
-<area shape="rect" coords="10,384,32,394" id="168" alt="rewind" onclick="pressMenuRemote('168');">
-<area shape="rect" coords="38,384,60,394" id="128" alt="stop" onclick="pressMenuRemote('128');">
-<area shape="rect" coords="64,384,86,394" id="164" alt="playpause" onclick="pressMenuRemote('164');">
-<area shape="rect" coords="92,384,114,394" id="208" alt="fastforward" onclick="pressMenuRemote('208');">
-<area shape="rect" coords="10,400,32,410" id="156" alt="plugin" onclick="pressMenuRemote('156');">
-<area shape="rect" coords="38,400,60,410" id="167" alt="record" onclick="pressMenuRemote('167');">
-<area shape="rect" coords="64,400,86,410" id="409" alt="slow" onclick="pressMenuRemote('409');">
-<area shape="rect" coords="92,400,114,410" id="142" alt="sleep" onclick="pressMenuRemote('142');">
-<area shape="rect" coords="10,418,32,428" id="370" alt="subtitle" onclick="pressMenuRemote('370');">
-<area shape="rect" coords="38,418,60,428" id="392" alt="audio" onclick="pressMenuRemote('392');">
-<area shape="rect" coords="64,418,86,428" id="388" alt="text" onclick="pressMenuRemote('388');">
-<area shape="rect" coords="92,418,114,428" id="138" alt="help" onclick="pressMenuRemote('138');">
+<area shape="circle" coords="25,60,10" id="116" title="Power" onclick="pressMenuRemote('116');">
+<area shape="circle" coords="95,60,10" id="113" title="mute" onclick="pressMenuRemote('113');">
+<area shape="rect" coords="12,76,28,92" id="362" title="timer" onclick="pressMenuRemote('362');">
+<area shape="rect" coords="40,76,56,92" id="377" title="tv/radio" onclick="pressMenuRemote('377');">
+<area shape="rect" coords="67,76,83,92" id="227" title="video mode" onclick="pressMenuRemote('227');">
+<area shape="rect" coords="67,76,83,92" id="227" title="video mode" onclick="pressMenuRemote('227');">
+<area shape="rect" coords="95,76,111,92" id="364" title="fav" onclick="pressMenuRemote('364');">
+<area shape="rect" coords="11,99,37,111" id="2" title="1" onclick="pressMenuRemote('2');">
+<area shape="rect" coords="49,99,75,111" id="3" title="2" onclick="pressMenuRemote('3');">
+<area shape="rect" coords="87,99,113,111" id="4" title="3" onclick="pressMenuRemote('4');">
+<area shape="rect" coords="11,118,37,130" id="5" title="4" onclick="pressMenuRemote('5');">
+<area shape="rect" coords="49,118,75,130" id="6" title="5" onclick="pressMenuRemote('6');">
+<area shape="rect" coords="87,118,113,130" id="7" title="6" onclick="pressMenuRemote('7');">
+<area shape="rect" coords="11,138,37,150" id="8" title="7" onclick="pressMenuRemote('8');">
+<area shape="rect" coords="49,138,75,150" id="9" title="8" onclick="pressMenuRemote('9');">
+<area shape="rect" coords="87,138,113,150" id="10" title="9" onclick="pressMenuRemote('10');">
+<area shape="rect" coords="11,157,37,169" id="412" title="previous" onclick="pressMenuRemote('412');">
+<area shape="rect" coords="49,157,75,169" id="11" title="0" onclick="pressMenuRemote('11');">
+<area shape="rect" coords="87,157,113,169" id="407" title="next" onclick="pressMenuRemote('407');">
+<area shape="rect" coords="51,181,73,203" id="226" title="media" onclick="pressMenuRemote('226');">
+<area shape="rect" coords="11,180,35,208" id="115" title="volume up" onclick="pressMenuRemote('115');">
+<area shape="rect" coords="89,180,113,208" id="402" title="channel up" onclick="pressMenuRemote('402');">
+<area shape="rect" coords="11,210,35,238" id="114" title="volume down" onclick="pressMenuRemote('114');">
+<area shape="rect" coords="89,210,113,238" id="403" title="channel down" onclick="pressMenuRemote('403');">
+<area shape="rect" coords="51,215,73,237" id="365" title="epg" onclick="pressMenuRemote('365');">
+<area shape="circle" coords="24,258,12" id="174" title="exit" onclick="pressMenuRemote('174');">
+<area shape="circle" coords="100,258,12" id="139" title="menu" onclick="pressMenuRemote('139');">
+<area shape="circle" coords="62,262,12" id="103" title="up" onclick="pressMenuRemote('103');">
+<area shape="circle" coords="25,296,12" id="105" title="left" onclick="pressMenuRemote('105');">
+<area shape="circle" coords="62,296,18" id="352" title="ok" onclick="pressMenuRemote('352');">
+<area shape="circle" coords="99,296,12" id="106" title="right" onclick="pressMenuRemote('106');">
+<area shape="circle" coords="62,333,12" id="108" title="down" onclick="pressMenuRemote('108');">
+<area shape="circle" coords="24,334,12" id="405" title="back" onclick="pressMenuRemote('405');">
+<area shape="circle" coords="100,334,12" id="358" title="info" onclick="pressMenuRemote('358');">
+<area shape="rect" coords="12,353,28,369" id="398" title="red" onclick="pressMenuRemote('398');">
+<area shape="rect" coords="40,353,56,369" id="399" title="green" onclick="pressMenuRemote('399');">
+<area shape="rect" coords="67,353,83,369" id="400" title="yellow" onclick="pressMenuRemote('400');">
+<area shape="rect" coords="95,353,111,369" id="401" title="blue" onclick="pressMenuRemote('401');">
+<area shape="rect" coords="10,384,32,394" id="168" title="rewind" onclick="pressMenuRemote('168');">
+<area shape="rect" coords="38,384,60,394" id="128" title="stop" onclick="pressMenuRemote('128');">
+<area shape="rect" coords="64,384,86,394" id="164" title="playpause" onclick="pressMenuRemote('164');">
+<area shape="rect" coords="92,384,114,394" id="208" title="fastforward" onclick="pressMenuRemote('208');">
+<area shape="rect" coords="10,400,32,410" id="156" title="plugin" onclick="pressMenuRemote('156');">
+<area shape="rect" coords="38,400,60,410" id="167" title="record" onclick="pressMenuRemote('167');">
+<area shape="rect" coords="64,400,86,410" id="409" title="slow" onclick="pressMenuRemote('409');">
+<area shape="rect" coords="92,400,114,410" id="142" title="sleep" onclick="pressMenuRemote('142');">
+<area shape="rect" coords="10,418,32,428" id="370" title="subtitle" onclick="pressMenuRemote('370');">
+<area shape="rect" coords="38,418,60,428" id="392" title="audio" onclick="pressMenuRemote('392');">
+<area shape="rect" coords="64,418,86,428" id="388" title="text" onclick="pressMenuRemote('388');">
+<area shape="rect" coords="92,418,114,428" id="138" title="help" onclick="pressMenuRemote('138');">
 </map>

--- a/BoxBranding/remotes/ini5/remote.html
+++ b/BoxBranding/remotes/ini5/remote.html
@@ -1,62 +1,62 @@
 <img border='0' src='/static/remotes/ini5/rc.png' usemap='#map' >
 <map name="map">
-	<area shape="circle" coords="55,30,12" alt="Power" onclick="pressMenuRemote('116');">
-	<area shape="circle" coords="23,58,12" alt="1" onclick="pressMenuRemote('2');">
-	<area shape="circle" coords="55,58,12" alt="2" onclick="pressMenuRemote('3');">
-	<area shape="circle" coords="87,58,12" alt="3" onclick="pressMenuRemote('4');">
-	<area shape="circle" coords="23,78,12" alt="4" onclick="pressMenuRemote('5');">
-	<area shape="circle" coords="55,78,12" alt="5" onclick="pressMenuRemote('6');">
-	<area shape="circle" coords="87,78,12" alt="6" onclick="pressMenuRemote('7');">
-	<area shape="circle" coords="23,98,12" alt="7" onclick="pressMenuRemote('8');">
-	<area shape="circle" coords="55,98,12" alt="8" onclick="pressMenuRemote('9');">
-	<area shape="circle" coords="87,98,12" alt="9" onclick="pressMenuRemote('10');">
-	<area shape="circle" coords="23,117,12" alt="previous" onclick="pressMenuRemote('412');">
-	<area shape="circle" coords="55,117,12" alt="0" onclick="pressMenuRemote('11');">
-	<area shape="circle" coords="87,117,12" alt="next" onclick="pressMenuRemote('407');">
+	<area shape="circle" coords="55,30,12" title="Power" onclick="pressMenuRemote('116');">
+	<area shape="circle" coords="23,58,12" title="1" onclick="pressMenuRemote('2');">
+	<area shape="circle" coords="55,58,12" title="2" onclick="pressMenuRemote('3');">
+	<area shape="circle" coords="87,58,12" title="3" onclick="pressMenuRemote('4');">
+	<area shape="circle" coords="23,78,12" title="4" onclick="pressMenuRemote('5');">
+	<area shape="circle" coords="55,78,12" title="5" onclick="pressMenuRemote('6');">
+	<area shape="circle" coords="87,78,12" title="6" onclick="pressMenuRemote('7');">
+	<area shape="circle" coords="23,98,12" title="7" onclick="pressMenuRemote('8');">
+	<area shape="circle" coords="55,98,12" title="8" onclick="pressMenuRemote('9');">
+	<area shape="circle" coords="87,98,12" title="9" onclick="pressMenuRemote('10');">
+	<area shape="circle" coords="23,117,12" title="previous" onclick="pressMenuRemote('412');">
+	<area shape="circle" coords="55,117,12" title="0" onclick="pressMenuRemote('11');">
+	<area shape="circle" coords="87,117,12" title="next" onclick="pressMenuRemote('407');">
 
-	<area shape="circle" coords="19,147,12" alt="epg" onclick="pressMenuRemote('365');">
-	<area shape="circle" coords="92,147,12" alt="fav" onclick="pressMenuRemote('364');">
-	<area shape="circle" coords="19,213,12" alt="menu" onclick="pressMenuRemote('139');">
-	<area shape="circle" coords="92,213,12" alt="exit" onclick="pressMenuRemote('174');">
+	<area shape="circle" coords="19,147,12" title="epg" onclick="pressMenuRemote('365');">
+	<area shape="circle" coords="92,147,12" title="fav" onclick="pressMenuRemote('364');">
+	<area shape="circle" coords="19,213,12" title="menu" onclick="pressMenuRemote('139');">
+	<area shape="circle" coords="92,213,12" title="exit" onclick="pressMenuRemote('174');">
 	
-	<area shape="circle" coords="55,180,15" alt="OK" onclick="pressMenuRemote('352');">
-	<area shape="circle" coords="55,155,12" alt="up" onclick="pressMenuRemote('103');">
-	<area shape="circle" coords="55,205,12" alt="down" onclick="pressMenuRemote('108');">
-	<area shape="circle" coords="30,180,12" alt="left" onclick="pressMenuRemote('105');">
-	<area shape="circle" coords="81,180,12" alt="right" onclick="pressMenuRemote('106');">
+	<area shape="circle" coords="55,180,15" title="OK" onclick="pressMenuRemote('352');">
+	<area shape="circle" coords="55,155,12" title="up" onclick="pressMenuRemote('103');">
+	<area shape="circle" coords="55,205,12" title="down" onclick="pressMenuRemote('108');">
+	<area shape="circle" coords="30,180,12" title="left" onclick="pressMenuRemote('105');">
+	<area shape="circle" coords="81,180,12" title="right" onclick="pressMenuRemote('106');">
 	
-	<area shape="circle" coords="22,244,12" alt="info" onclick="pressMenuRemote('358');">
-	<area shape="circle" coords="55,244,15" alt="media" onclick="pressMenuRemote('226');">
-	<area shape="circle" coords="89,244,12" alt="back" onclick="pressMenuRemote('405');">
+	<area shape="circle" coords="22,244,12" title="info" onclick="pressMenuRemote('358');">
+	<area shape="circle" coords="55,244,15" title="media" onclick="pressMenuRemote('226');">
+	<area shape="circle" coords="89,244,12" title="back" onclick="pressMenuRemote('405');">
 	
-	<area shape="circle" coords="22,272,12" alt="volume up" onclick="pressMenuRemote('115');">
-	<area shape="circle" coords="22,304,12" alt="volume down" onclick="pressMenuRemote('114');">
-	<area shape="circle" coords="55,287,10" alt="mute" onclick="pressMenuRemote('113');">
-	<area shape="circle" coords="88,272,12" alt="channel up" onclick="pressMenuRemote('402');">
-	<area shape="circle" coords="88,304,12" alt="channel down" onclick="pressMenuRemote('403');">
+	<area shape="circle" coords="22,272,12" title="volume up" onclick="pressMenuRemote('115');">
+	<area shape="circle" coords="22,304,12" title="volume down" onclick="pressMenuRemote('114');">
+	<area shape="circle" coords="55,287,10" title="mute" onclick="pressMenuRemote('113');">
+	<area shape="circle" coords="88,272,12" title="channel up" onclick="pressMenuRemote('402');">
+	<area shape="circle" coords="88,304,12" title="channel down" onclick="pressMenuRemote('403');">
 	
-	<area shape="circle" coords="19,332,10" alt="red" onclick="pressMenuRemote('398');">
-	<area shape="circle" coords="43,332,10" alt="green" onclick="pressMenuRemote('399');">
-	<area shape="circle" coords="67,332,10" alt="yellow" onclick="pressMenuRemote('400');">
-	<area shape="circle" coords="91,332,10" alt="blue" onclick="pressMenuRemote('401');">
+	<area shape="circle" coords="19,332,10" title="red" onclick="pressMenuRemote('398');">
+	<area shape="circle" coords="43,332,10" title="green" onclick="pressMenuRemote('399');">
+	<area shape="circle" coords="67,332,10" title="yellow" onclick="pressMenuRemote('400');">
+	<area shape="circle" coords="91,332,10" title="blue" onclick="pressMenuRemote('401');">
 
-	<area shape="circle" coords="19,352,10" alt="rewind" onclick="pressMenuRemote('168');">
-	<area shape="circle" coords="43,352,10" alt="playpause" onclick="pressMenuRemote('164');">
-	<area shape="circle" coords="67,352,10" alt="stop" onclick="pressMenuRemote('128');">
-	<area shape="circle" coords="91,352,10" alt="forward" onclick="pressMenuRemote('208');">
+	<area shape="circle" coords="19,352,10" title="rewind" onclick="pressMenuRemote('168');">
+	<area shape="circle" coords="43,352,10" title="playpause" onclick="pressMenuRemote('164');">
+	<area shape="circle" coords="67,352,10" title="stop" onclick="pressMenuRemote('128');">
+	<area shape="circle" coords="91,352,10" title="forward" onclick="pressMenuRemote('208');">
 
-	<area shape="circle" coords="19,370,10" alt="record" onclick="pressMenuRemote('167');">
-	<area shape="circle" coords="43,370,10" alt="timer" onclick="pressMenuRemote('362');">
-	<area shape="circle" coords="67,370,10" alt="web" onclick="pressMenuRemote('217');">
-	<area shape="circle" coords="91,370,10" alt="plugin" onclick="pressMenuRemote('156');">
+	<area shape="circle" coords="19,370,10" title="record" onclick="pressMenuRemote('167');">
+	<area shape="circle" coords="43,370,10" title="timer" onclick="pressMenuRemote('362');">
+	<area shape="circle" coords="67,370,10" title="web" onclick="pressMenuRemote('217');">
+	<area shape="circle" coords="91,370,10" title="plugin" onclick="pressMenuRemote('156');">
 	
-	<area shape="circle" coords="19,398,10" alt="audio" onclick="pressMenuRemote('392');">
-	<area shape="circle" coords="43,398,10" alt="pip" onclick="pressMenuRemote('375');">
-	<area shape="circle" coords="67,398,10" alt="subtitle" onclick="pressMenuRemote('370');">
-	<area shape="circle" coords="91,398,10" alt="sleep" onclick="pressMenuRemote('142');">
+	<area shape="circle" coords="19,398,10" title="audio" onclick="pressMenuRemote('392');">
+	<area shape="circle" coords="43,398,10" title="pip" onclick="pressMenuRemote('375');">
+	<area shape="circle" coords="67,398,10" title="subtitle" onclick="pressMenuRemote('370');">
+	<area shape="circle" coords="91,398,10" title="sleep" onclick="pressMenuRemote('142');">
 
-	<area shape="circle" coords="19,416,10" alt="text" onclick="pressMenuRemote('388');">
-	<area shape="circle" coords="43,416,10" alt="tv" onclick="pressMenuRemote('377');">
-	<area shape="circle" coords="67,416,10" alt="radio" onclick="pressMenuRemote('385');">
-	<area shape="circle" coords="91,416,10" alt="help" onclick="pressMenuRemote('138');">
+	<area shape="circle" coords="19,416,10" title="text" onclick="pressMenuRemote('388');">
+	<area shape="circle" coords="43,416,10" title="tv" onclick="pressMenuRemote('377');">
+	<area shape="circle" coords="67,416,10" title="radio" onclick="pressMenuRemote('385');">
+	<area shape="circle" coords="91,416,10" title="help" onclick="pressMenuRemote('138');">
 </map>

--- a/BoxBranding/remotes/ini7/remote.html
+++ b/BoxBranding/remotes/ini7/remote.html
@@ -1,63 +1,63 @@
 <img border='0' src='/static/remotes/ini7/rc.png' usemap='#map' >
 <map name="map">
-	<area shape="circle" coords="52,27,12" alt="Power" onclick="pressMenuRemote('116');">
+	<area shape="circle" coords="52,27,12" title="Power" onclick="pressMenuRemote('116');">
 
-	<area shape="circle" coords="22,56,12" alt="1" onclick="pressMenuRemote('2');">
-	<area shape="circle" coords="52,56,12" alt="2" onclick="pressMenuRemote('3');">
-	<area shape="circle" coords="82,56,12" alt="3" onclick="pressMenuRemote('4');">
-	<area shape="circle" coords="22,75,12" alt="4" onclick="pressMenuRemote('5');">
-	<area shape="circle" coords="52,75,12" alt="5" onclick="pressMenuRemote('6');">
-	<area shape="circle" coords="82,75,12" alt="6" onclick="pressMenuRemote('7');">
-	<area shape="circle" coords="22,95,12" alt="7" onclick="pressMenuRemote('8');">
-	<area shape="circle" coords="52,95,12" alt="8" onclick="pressMenuRemote('9');">
-	<area shape="circle" coords="82,95,12" alt="9" onclick="pressMenuRemote('10');">
-	<area shape="circle" coords="22,114,12" alt="previous" onclick="pressMenuRemote('412');">
-	<area shape="circle" coords="52,114,12" alt="0" onclick="pressMenuRemote('11');">
-	<area shape="circle" coords="82,114,12" alt="next" onclick="pressMenuRemote('407');">
+	<area shape="circle" coords="22,56,12" title="1" onclick="pressMenuRemote('2');">
+	<area shape="circle" coords="52,56,12" title="2" onclick="pressMenuRemote('3');">
+	<area shape="circle" coords="82,56,12" title="3" onclick="pressMenuRemote('4');">
+	<area shape="circle" coords="22,75,12" title="4" onclick="pressMenuRemote('5');">
+	<area shape="circle" coords="52,75,12" title="5" onclick="pressMenuRemote('6');">
+	<area shape="circle" coords="82,75,12" title="6" onclick="pressMenuRemote('7');">
+	<area shape="circle" coords="22,95,12" title="7" onclick="pressMenuRemote('8');">
+	<area shape="circle" coords="52,95,12" title="8" onclick="pressMenuRemote('9');">
+	<area shape="circle" coords="82,95,12" title="9" onclick="pressMenuRemote('10');">
+	<area shape="circle" coords="22,114,12" title="previous" onclick="pressMenuRemote('412');">
+	<area shape="circle" coords="52,114,12" title="0" onclick="pressMenuRemote('11');">
+	<area shape="circle" coords="82,114,12" title="next" onclick="pressMenuRemote('407');">
 
-	<area shape="circle" coords="19,145,12" alt="exit" onclick="pressMenuRemote('174');">
-	<area shape="circle" coords="86,145,12" alt="menu" onclick="pressMenuRemote('139');">
-	<area shape="circle" coords="19,208,12" alt="back" onclick="pressMenuRemote('405');">
-	<area shape="circle" coords="86,208,12" alt="info" onclick="pressMenuRemote('358');">
+	<area shape="circle" coords="19,145,12" title="exit" onclick="pressMenuRemote('174');">
+	<area shape="circle" coords="86,145,12" title="menu" onclick="pressMenuRemote('139');">
+	<area shape="circle" coords="19,208,12" title="back" onclick="pressMenuRemote('405');">
+	<area shape="circle" coords="86,208,12" title="info" onclick="pressMenuRemote('358');">
 
-	<area shape="circle" coords="52,177,15" alt="OK" onclick="pressMenuRemote('352');">
-	<area shape="circle" coords="52,153,12" alt="up" onclick="pressMenuRemote('103');">
-	<area shape="circle" coords="52,201,12" alt="down" onclick="pressMenuRemote('108');">
-	<area shape="circle" coords="28,177,12" alt="left" onclick="pressMenuRemote('105');">
-	<area shape="circle" coords="76,177,12" alt="right" onclick="pressMenuRemote('106');">
+	<area shape="circle" coords="52,177,15" title="OK" onclick="pressMenuRemote('352');">
+	<area shape="circle" coords="52,153,12" title="up" onclick="pressMenuRemote('103');">
+	<area shape="circle" coords="52,201,12" title="down" onclick="pressMenuRemote('108');">
+	<area shape="circle" coords="28,177,12" title="left" onclick="pressMenuRemote('105');">
+	<area shape="circle" coords="76,177,12" title="right" onclick="pressMenuRemote('106');">
 	
-	<area shape="circle" coords="17,235,12" alt="red" onclick="pressMenuRemote('398');">
-	<area shape="circle" coords="41,235,12" alt="green" onclick="pressMenuRemote('399');">
-	<area shape="circle" coords="63,235,12" alt="yellow" onclick="pressMenuRemote('400');">
-	<area shape="circle" coords="87,235,12" alt="blue" onclick="pressMenuRemote('401');">
+	<area shape="circle" coords="17,235,12" title="red" onclick="pressMenuRemote('398');">
+	<area shape="circle" coords="41,235,12" title="green" onclick="pressMenuRemote('399');">
+	<area shape="circle" coords="63,235,12" title="yellow" onclick="pressMenuRemote('400');">
+	<area shape="circle" coords="87,235,12" title="blue" onclick="pressMenuRemote('401');">
 
-	<area shape="circle" coords="20,262,12" alt="volume up" onclick="pressMenuRemote('115');">
-	<area shape="circle" coords="20,290,12" alt="volume down" onclick="pressMenuRemote('114');">
-	<area shape="circle" coords="52,275,12" alt="mute" onclick="pressMenuRemote('113');">
-	<area shape="circle" coords="84,262,12" alt="channel up" onclick="pressMenuRemote('402');">
-	<area shape="circle" coords="84,290,12" alt="channel down" onclick="pressMenuRemote('403');">
+	<area shape="circle" coords="20,262,12" title="volume up" onclick="pressMenuRemote('115');">
+	<area shape="circle" coords="20,290,12" title="volume down" onclick="pressMenuRemote('114');">
+	<area shape="circle" coords="52,275,12" title="mute" onclick="pressMenuRemote('113');">
+	<area shape="circle" coords="84,262,12" title="channel up" onclick="pressMenuRemote('402');">
+	<area shape="circle" coords="84,290,12" title="channel down" onclick="pressMenuRemote('403');">
 	
-	<area shape="circle" coords="22,317,12" alt="timer" onclick="pressMenuRemote('362');">
-	<area shape="circle" coords="52,317,12" alt="media" onclick="pressMenuRemote('226');">
-	<area shape="circle" coords="82,317,12" alt="epg" onclick="pressMenuRemote('365');">
+	<area shape="circle" coords="22,317,12" title="timer" onclick="pressMenuRemote('362');">
+	<area shape="circle" coords="52,317,12" title="media" onclick="pressMenuRemote('226');">
+	<area shape="circle" coords="82,317,12" title="epg" onclick="pressMenuRemote('365');">
 
-	<area shape="circle" coords="18,344,10" alt="rewind" onclick="pressMenuRemote('168');">
-	<area shape="circle" coords="40,344,10" alt="stop" onclick="pressMenuRemote('128');">
-	<area shape="circle" coords="64,344,10" alt="playpause" onclick="pressMenuRemote('164');">
-	<area shape="circle" coords="86,344,10" alt="forward" onclick="pressMenuRemote('208');">
+	<area shape="circle" coords="18,344,10" title="rewind" onclick="pressMenuRemote('168');">
+	<area shape="circle" coords="40,344,10" title="stop" onclick="pressMenuRemote('128');">
+	<area shape="circle" coords="64,344,10" title="playpause" onclick="pressMenuRemote('164');">
+	<area shape="circle" coords="86,344,10" title="forward" onclick="pressMenuRemote('208');">
 
-	<area shape="circle" coords="18,363,10" alt="record" onclick="pressMenuRemote('167');">
-	<area shape="circle" coords="40,363,10" alt="fav" onclick="pressMenuRemote('364');">
-	<area shape="circle" coords="64,363,10" alt="web" onclick="pressMenuRemote('217');">
-	<area shape="circle" coords="86,363,10" alt="plugin" onclick="pressMenuRemote('156');">
+	<area shape="circle" coords="18,363,10" title="record" onclick="pressMenuRemote('167');">
+	<area shape="circle" coords="40,363,10" title="fav" onclick="pressMenuRemote('364');">
+	<area shape="circle" coords="64,363,10" title="web" onclick="pressMenuRemote('217');">
+	<area shape="circle" coords="86,363,10" title="plugin" onclick="pressMenuRemote('156');">
 	
-	<area shape="circle" coords="18,382,10" alt="audio" onclick="pressMenuRemote('392');">
-	<area shape="circle" coords="40,382,10" alt="pip" onclick="pressMenuRemote('375');">
-	<area shape="circle" coords="64,382,10" alt="subtitle" onclick="pressMenuRemote('370');">
-	<area shape="circle" coords="86,382,10" alt="sleep" onclick="pressMenuRemote('142');">
+	<area shape="circle" coords="18,382,10" title="audio" onclick="pressMenuRemote('392');">
+	<area shape="circle" coords="40,382,10" title="pip" onclick="pressMenuRemote('375');">
+	<area shape="circle" coords="64,382,10" title="subtitle" onclick="pressMenuRemote('370');">
+	<area shape="circle" coords="86,382,10" title="sleep" onclick="pressMenuRemote('142');">
 
-	<area shape="circle" coords="18,401,10" alt="text" onclick="pressMenuRemote('388');">
-	<area shape="circle" coords="40,401,10" alt="tv" onclick="pressMenuRemote('377');">
-	<area shape="circle" coords="64,401,10" alt="radio" onclick="pressMenuRemote('385');">
-	<area shape="circle" coords="86,401,10" alt="help" onclick="pressMenuRemote('138');">
+	<area shape="circle" coords="18,401,10" title="text" onclick="pressMenuRemote('388');">
+	<area shape="circle" coords="40,401,10" title="tv" onclick="pressMenuRemote('377');">
+	<area shape="circle" coords="64,401,10" title="radio" onclick="pressMenuRemote('385');">
+	<area shape="circle" coords="86,401,10" title="help" onclick="pressMenuRemote('138');">
 </map>


### PR DESCRIPTION
Fixups to Beyonwiz remotes.html files to use title= instead of alt= for tooltip text and to add a leading '/' to image paths that don't have them.