### PR TITLE
Bulk removal of area "id =" attribites in remote.html files

### DIFF
--- a/BoxBranding/remotes/ebox5000/remote.html
+++ b/BoxBranding/remotes/ebox5000/remote.html
@@ -1,40 +1,40 @@
 <img border='0' src='/static/remotes/ebox5000/rc.png' usemap='#map' >
 <map name="map">
 	<area shape="rect" coords="98,62,118,72" title="mute" onclick="pressMenuRemote('113');">
-	<area shape="rect" coords="105,28,15" id ="116" title="Power" onclick="pressMenuRemote('116');">
-	<area shape="rect" coords="33,53,15" id ="388" title="text" onclick="pressMenuRemote('388');">
-	<area shape="rect" coords="58,53,15" id ="370" title="subtitle" onclick="pressMenuRemote('370');">
-	<area shape="rect" coords="82,53,15" id ="102" title="home" onclick="pressMenuRemote('102');">
-	<area shape="rect" coords="105,53,15" id ="107" title="end" onclick="pressMenuRemote('107');">
+	<area shape="rect" coords="105,28,15" title="Power" onclick="pressMenuRemote('116');">
+	<area shape="rect" coords="33,53,15" title="text" onclick="pressMenuRemote('388');">
+	<area shape="rect" coords="58,53,15" title="subtitle" onclick="pressMenuRemote('370');">
+	<area shape="rect" coords="82,53,15" title="home" onclick="pressMenuRemote('102');">
+	<area shape="rect" coords="105,53,15" title="end" onclick="pressMenuRemote('107');">
 
-	<area shape="rect" coords="20,62,40,72" id ="2" title="1" onclick="pressMenuRemote('2');">
-	<area shape="rect" coords="46,62,66,72" id ="3" title="2" onclick="pressMenuRemote('3');">
-	<area shape="rect" coords="72,62,92,72" id ="4" title="3" onclick="pressMenuRemote('4');">
-	<area shape="rect" coords="20,78,40,88" id ="5" title="4" onclick="pressMenuRemote('5');">
-	<area shape="rect" coords="46,78,66,88" id ="6" title="5" onclick="pressMenuRemote('6');">
-	<area shape="rect" coords="72,78,92,88" id ="7" title="6" onclick="pressMenuRemote('7');">
-	<area shape="rect" coords="20,96,40,106" id ="8" title="7" onclick="pressMenuRemote('8');">
-	<area shape="rect" coords="46,96,66,106" id ="9" title="8" onclick="pressMenuRemote('9');">
-	<area shape="rect" coords="72,62,92,106" id ="10" title="9" onclick="pressMenuRemote('10');">
-	<area shape="rect" coords="46,112,66,125" id ="11" title="0" onclick="pressMenuRemote('11');">
+	<area shape="rect" coords="20,62,40,72" title="1" onclick="pressMenuRemote('2');">
+	<area shape="rect" coords="46,62,66,72" title="2" onclick="pressMenuRemote('3');">
+	<area shape="rect" coords="72,62,92,72" title="3" onclick="pressMenuRemote('4');">
+	<area shape="rect" coords="20,78,40,88" title="4" onclick="pressMenuRemote('5');">
+	<area shape="rect" coords="46,78,66,88" title="5" onclick="pressMenuRemote('6');">
+	<area shape="rect" coords="72,78,92,88" title="6" onclick="pressMenuRemote('7');">
+	<area shape="rect" coords="20,96,40,106" title="7" onclick="pressMenuRemote('8');">
+	<area shape="rect" coords="46,96,66,106" title="8" onclick="pressMenuRemote('9');">
+	<area shape="rect" coords="72,62,92,106" title="9" onclick="pressMenuRemote('10');">
+	<area shape="rect" coords="46,112,66,125" title="0" onclick="pressMenuRemote('11');">
 
 	<!-- Added Key -->
 	<area shape="rect" coords="96,95,118,107" title="Lan" onclick="pressMenuRemote(59);">
-	<area shape="circle" coords="104,214,18" id ="174" title="exit" onclick="pressMenuRemote('174');">
+	<area shape="circle" coords="104,214,18" title="exit" onclick="pressMenuRemote('174');">
 
-	<area shape="rect" coords="94,134,117,154" id ="402" title="channelup" onclick="pressMenuRemote('402');">
-	<area shape="rect" coords="94,174,117,194" id ="403" title="channeldown" onclick="pressMenuRemote('403');">
+	<area shape="rect" coords="94,134,117,154" title="channelup" onclick="pressMenuRemote('402');">
+	<area shape="rect" coords="94,174,117,194" title="channeldown" onclick="pressMenuRemote('403');">
 
-	<area shape="rect" coords="20,134,40,154" id ="115" title="volume up" onclick="pressMenuRemote('115');">
-	<area shape="rect" coords="20,174,40,194" id ="114" title="volume down" onclick="pressMenuRemote('114');">
+	<area shape="rect" coords="20,134,40,154" title="volume up" onclick="pressMenuRemote('115');">
+	<area shape="rect" coords="20,174,40,194" title="volume down" onclick="pressMenuRemote('114');">
 
-	<area shape="rect" coords="20,112,40,125" id ="412" title="previous" onclick="pressMenuRemote('412');">
-	<area shape="rect" coords="72,112,92,125" id ="407" title="next" onclick="pressMenuRemote('407');">
+	<area shape="rect" coords="20,112,40,125" title="previous" onclick="pressMenuRemote('412');">
+	<area shape="rect" coords="72,112,92,125" title="next" onclick="pressMenuRemote('407');">
 
-	<area shape="rect" coords="20,323,41,332" id ="398" title="red" onclick="pressMenuRemote('398');">
-	<area shape="rect" coords="45,323,66,332" id ="399" title="green" onclick="pressMenuRemote('399');">
-	<area shape="rect" coords="70,323,91,332" id ="400" title="yellow" onclick="pressMenuRemote('400');">
-	<area shape="rect" coords="95,323,116,332" id ="401" title="blue" onclick="pressMenuRemote('401');">
+	<area shape="rect" coords="20,323,41,332" title="red" onclick="pressMenuRemote('398');">
+	<area shape="rect" coords="45,323,66,332" title="green" onclick="pressMenuRemote('399');">
+	<area shape="rect" coords="70,323,91,332" title="yellow" onclick="pressMenuRemote('400');">
+	<area shape="rect" coords="95,323,116,332" title="blue" onclick="pressMenuRemote('401');">
 
 	<area shape="circle" coords="69,145,15" title="EPGPressed" onclick="pressMenuRemote(365);">
 	<area shape="circle" coords="33,280,20" title="openSatellites" onclick="pressMenuRemote(381);">
@@ -67,74 +67,74 @@
 	<!-- Rf modulator -->
 	<area shape="rect" coords="98,114,116,124" title="showRFmod" onclick="pressMenuRemote(63);">
 
-	<area shape="circle" coords="70,213,15" id ="103" title="up" onclick="pressMenuRemote('103');">
-	<area shape="circle" coords="70,283,15" id ="108" title="down" onclick="pressMenuRemote('108');">
-	<area shape="circle" coords="35,248,15" id ="105" title="left" onclick="pressMenuRemote('105');">
-	<area shape="circle" coords="105,248,15" id ="106" title="right" onclick="pressMenuRemote('106');">
+	<area shape="circle" coords="70,213,15" title="up" onclick="pressMenuRemote('103');">
+	<area shape="circle" coords="70,283,15" title="down" onclick="pressMenuRemote('108');">
+	<area shape="circle" coords="35,248,15" title="left" onclick="pressMenuRemote('105');">
+	<area shape="circle" coords="105,248,15" title="right" onclick="pressMenuRemote('106');">
 
-	<area shape="circle" coords="70,248,20" id ="352" title="OK" onclick="pressMenuRemote('352');">
-	<area shape="circle" coords="69,180,15" id ="392" title="audio" onclick="pressMenuRemote('392');">
+	<area shape="circle" coords="70,248,20" title="OK" onclick="pressMenuRemote('352');">
+	<area shape="circle" coords="69,180,15" title="audio" onclick="pressMenuRemote('392');">
 
-	<area shape="circle" coords="32,214,18" id ="139" title="menu" onclick="pressMenuRemote('139');">
-	<area shape="rect" coords="55,342,82,358" id ="167" title="record" onclick="pressMenuRemote('167');">
-	<area shape="rect" coords="20,342,46,357" id ="393" title="videoaltlast" onclick="pressMenuRemote('393');">
+	<area shape="circle" coords="32,214,18" title="menu" onclick="pressMenuRemote('139');">
+	<area shape="rect" coords="55,342,82,358" title="record" onclick="pressMenuRemote('167');">
+	<area shape="rect" coords="20,342,46,357" title="videoaltlast" onclick="pressMenuRemote('393');">
 
-	<area shape="rect" coords="98,78,118,88" id ="138" title="help" onclick="pressMenuRemote('138');">
+	<area shape="rect" coords="98,78,118,88" title="help" onclick="pressMenuRemote('138');">
 
-	<area shape="circle" coords="36,383,15" id ="168" title="rewind" onclick="pressMenuRemote('168');">
-	<area shape="circle" coords="59,383,15" id ="207" title="play" onclick="pressMenuRemote('207');">
-	<area shape="circle" coords="81,383,15" id ="119" title="pause" onclick="pressMenuRemote('119');">
-	<area shape="circle" coords="104,383,15" id ="208" title="forward" onclick="pressMenuRemote('208');">
-	<area shape="circle" coords="36,405,15" id ="377" title="tv" onclick="pressMenuRemote('377');">
+	<area shape="circle" coords="36,383,15" title="rewind" onclick="pressMenuRemote('168');">
+	<area shape="circle" coords="59,383,15" title="play" onclick="pressMenuRemote('207');">
+	<area shape="circle" coords="81,383,15" title="pause" onclick="pressMenuRemote('119');">
+	<area shape="circle" coords="104,383,15" title="forward" onclick="pressMenuRemote('208');">
+	<area shape="circle" coords="36,405,15" title="tv" onclick="pressMenuRemote('377');">
 
 
-	<area shape="circle" coords="81,405,15" id ="128" title="stop" onclick="pressMenuRemote('128');">
-	<area shape="circle" coords="104,405,15" id ="385" title="radio" onclick="pressMenuRemote('385');">
+	<area shape="circle" coords="81,405,15" title="stop" onclick="pressMenuRemote('128');">
+	<area shape="circle" coords="104,405,15" title="radio" onclick="pressMenuRemote('385');">
 </map>
 <!--
 	<area shape="circle" coords="33,28,15" title="mute" onclick="pressMenuRemote('113');">
-	<area shape="circle" coords="105,28,15" id ="116" title="Power" onclick="pressMenuRemote('116');">
-	<area shape="circle" coords="33,53,15" id ="388" title="text" onclick="pressMenuRemote('388');">
-	<area shape="circle" coords="58,53,15" id ="370" title="subtitle" onclick="pressMenuRemote('370');">
-	<area shape="circle" coords="82,53,15" id ="102" title="home" onclick="pressMenuRemote('102');">
-	<area shape="circle" coords="105,53,15" id ="107" title="end" onclick="pressMenuRemote('107');">
-	<area shape="circle" coords="38,79,15" id ="2" title="1" onclick="pressMenuRemote('2');">
-	<area shape="circle" coords="70,79,15" id ="3" title="2" onclick="pressMenuRemote('3');">
-	<area shape="circle" coords="102,79,15" id ="4" title="3" onclick="pressMenuRemote('4');">
-	<area shape="circle" coords="38,106,15" id ="5" title="4" onclick="pressMenuRemote('5');">
-	<area shape="circle" coords="70,106,15" id ="6" title="5" onclick="pressMenuRemote('6');">
-	<area shape="circle" coords="102,106,15" id ="7" title="6" onclick="pressMenuRemote('7');">
-	<area shape="circle" coords="38,133,15" id ="8" title="7" onclick="pressMenuRemote('8');">
-	<area shape="circle" coords="70,133,15" id ="9" title="8" onclick="pressMenuRemote('9');">
-	<area shape="circle" coords="102,133,15" id ="10" title="9" onclick="pressMenuRemote('10');">
-	<area shape="circle" coords="38,161,15" id ="412" title="previous" onclick="pressMenuRemote('412');">
-	<area shape="circle" coords="70,161,15" id ="11" title="0" onclick="pressMenuRemote('11');">
-	<area shape="circle" coords="102,161,15" id ="407" title="next" onclick="pressMenuRemote('407');">
-	<area shape="circle" coords="33,186,15" id ="398" title="red" onclick="pressMenuRemote('398');">
-	<area shape="circle" coords="58,186,15" id ="399" title="green" onclick="pressMenuRemote('399');">
-	<area shape="circle" coords="82,186,15" id ="400" title="yellow" onclick="pressMenuRemote('400');">
-	<area shape="circle" coords="105,186,15" id ="401" title="blue" onclick="pressMenuRemote('401');">
-	<area shape="circle" coords="70,213,15" id ="103" title="up" onclick="pressMenuRemote('103');">
-	<area shape="circle" coords="70,283,15" id ="108" title="down" onclick="pressMenuRemote('108');">
-	<area shape="circle" coords="35,248,15" id ="105" title="left" onclick="pressMenuRemote('105');">
-	<area shape="circle" coords="105,248,15" id ="106" title="right" onclick="pressMenuRemote('106');">
-	<area shape="circle" coords="70,248,20" id ="352" title="OK" onclick="pressMenuRemote('352');">
-	<area shape="circle" coords="40,307,15" id ="115" title="volume up" onclick="pressMenuRemote('115');">
-	<area shape="circle" coords="40,338,13" id ="114" title="volume down" onclick="pressMenuRemote('114');">
-	<area shape="circle" coords="70,310,15" id ="174" title="exit" onclick="pressMenuRemote('174');">
-	<area shape="circle" coords="70,334,15" id ="358" title="epg" onclick="pressMenuRemote('358');">
-	<area shape="circle" coords="99,307,15" id ="402" title="channelup" onclick="pressMenuRemote('402');">
-	<area shape="circle" coords="99,338,15" id ="403" title="channeldown" onclick="pressMenuRemote('403');">
-	<area shape="circle" coords="36,362,15" id ="139" title="menu" onclick="pressMenuRemote('139');">
-	<area shape="circle" coords="59,362,15" id ="393" title="videoaltlast" onclick="pressMenuRemote('393');">
-	<area shape="circle" coords="81,362,15" id ="392" title="audio" onclick="pressMenuRemote('392');">
-	<area shape="circle" coords="104,362,15" id ="138" title="help" onclick="pressMenuRemote('138');">
-	<area shape="circle" coords="36,383,15" id ="168" title="rewind" onclick="pressMenuRemote('168');">
-	<area shape="circle" coords="59,383,15" id ="207" title="play" onclick="pressMenuRemote('207');">
-	<area shape="circle" coords="81,383,15" id ="119" title="pause" onclick="pressMenuRemote('119');">
-	<area shape="circle" coords="104,383,15" id ="208" title="forward" onclick="pressMenuRemote('208');">
-	<area shape="circle" coords="36,405,15" id ="377" title="tv" onclick="pressMenuRemote('377');">
-	<area shape="circle" coords="59,405,15" id ="167" title="record" onclick="pressMenuRemote('167');">
-	<area shape="circle" coords="81,405,15" id ="128" title="stop" onclick="pressMenuRemote('128');">
-	<area shape="circle" coords="104,405,15" id ="385" title="radio" onclick="pressMenuRemote('385');">
+	<area shape="circle" coords="105,28,15" title="Power" onclick="pressMenuRemote('116');">
+	<area shape="circle" coords="33,53,15" title="text" onclick="pressMenuRemote('388');">
+	<area shape="circle" coords="58,53,15" title="subtitle" onclick="pressMenuRemote('370');">
+	<area shape="circle" coords="82,53,15" title="home" onclick="pressMenuRemote('102');">
+	<area shape="circle" coords="105,53,15" title="end" onclick="pressMenuRemote('107');">
+	<area shape="circle" coords="38,79,15" title="1" onclick="pressMenuRemote('2');">
+	<area shape="circle" coords="70,79,15" title="2" onclick="pressMenuRemote('3');">
+	<area shape="circle" coords="102,79,15" title="3" onclick="pressMenuRemote('4');">
+	<area shape="circle" coords="38,106,15" title="4" onclick="pressMenuRemote('5');">
+	<area shape="circle" coords="70,106,15" title="5" onclick="pressMenuRemote('6');">
+	<area shape="circle" coords="102,106,15" title="6" onclick="pressMenuRemote('7');">
+	<area shape="circle" coords="38,133,15" title="7" onclick="pressMenuRemote('8');">
+	<area shape="circle" coords="70,133,15" title="8" onclick="pressMenuRemote('9');">
+	<area shape="circle" coords="102,133,15" title="9" onclick="pressMenuRemote('10');">
+	<area shape="circle" coords="38,161,15" title="previous" onclick="pressMenuRemote('412');">
+	<area shape="circle" coords="70,161,15" title="0" onclick="pressMenuRemote('11');">
+	<area shape="circle" coords="102,161,15" title="next" onclick="pressMenuRemote('407');">
+	<area shape="circle" coords="33,186,15" title="red" onclick="pressMenuRemote('398');">
+	<area shape="circle" coords="58,186,15" title="green" onclick="pressMenuRemote('399');">
+	<area shape="circle" coords="82,186,15" title="yellow" onclick="pressMenuRemote('400');">
+	<area shape="circle" coords="105,186,15" title="blue" onclick="pressMenuRemote('401');">
+	<area shape="circle" coords="70,213,15" title="up" onclick="pressMenuRemote('103');">
+	<area shape="circle" coords="70,283,15" title="down" onclick="pressMenuRemote('108');">
+	<area shape="circle" coords="35,248,15" title="left" onclick="pressMenuRemote('105');">
+	<area shape="circle" coords="105,248,15" title="right" onclick="pressMenuRemote('106');">
+	<area shape="circle" coords="70,248,20" title="OK" onclick="pressMenuRemote('352');">
+	<area shape="circle" coords="40,307,15" title="volume up" onclick="pressMenuRemote('115');">
+	<area shape="circle" coords="40,338,13" title="volume down" onclick="pressMenuRemote('114');">
+	<area shape="circle" coords="70,310,15" title="exit" onclick="pressMenuRemote('174');">
+	<area shape="circle" coords="70,334,15" title="epg" onclick="pressMenuRemote('358');">
+	<area shape="circle" coords="99,307,15" title="channelup" onclick="pressMenuRemote('402');">
+	<area shape="circle" coords="99,338,15" title="channeldown" onclick="pressMenuRemote('403');">
+	<area shape="circle" coords="36,362,15" title="menu" onclick="pressMenuRemote('139');">
+	<area shape="circle" coords="59,362,15" title="videoaltlast" onclick="pressMenuRemote('393');">
+	<area shape="circle" coords="81,362,15" title="audio" onclick="pressMenuRemote('392');">
+	<area shape="circle" coords="104,362,15" title="help" onclick="pressMenuRemote('138');">
+	<area shape="circle" coords="36,383,15" title="rewind" onclick="pressMenuRemote('168');">
+	<area shape="circle" coords="59,383,15" title="play" onclick="pressMenuRemote('207');">
+	<area shape="circle" coords="81,383,15" title="pause" onclick="pressMenuRemote('119');">
+	<area shape="circle" coords="104,383,15" title="forward" onclick="pressMenuRemote('208');">
+	<area shape="circle" coords="36,405,15" title="tv" onclick="pressMenuRemote('377');">
+	<area shape="circle" coords="59,405,15" title="record" onclick="pressMenuRemote('167');">
+	<area shape="circle" coords="81,405,15" title="stop" onclick="pressMenuRemote('128');">
+	<area shape="circle" coords="104,405,15" title="radio" onclick="pressMenuRemote('385');">
 	-->

--- a/BoxBranding/remotes/fusionhd/remote.html
+++ b/BoxBranding/remotes/fusionhd/remote.html
@@ -1,62 +1,62 @@
 <img border='0' src='/static/remotes/fusionhd/rc.png' usemap='#map' >
 <map name="map">
-	<area shape="rect" coords="24,44,51,58" id ="138" title="help" onclick="pressMenuRemote('138');">
-	<area shape="rect" coords="58,44,84,56" id ="172" title="home" onclick="pressMenuRemote('172');">
-	<area shape="rect" coords="90,44,117,56" id ="107" title="end" onclick="pressMenuRemote('107');">
-	<area shape="rect" coords="58,66,84,78" id ="370" title="subtitle" onclick="pressMenuRemote('370');">
+	<area shape="rect" coords="24,44,51,58" title="help" onclick="pressMenuRemote('138');">
+	<area shape="rect" coords="58,44,84,56" title="home" onclick="pressMenuRemote('172');">
+	<area shape="rect" coords="90,44,117,56" title="end" onclick="pressMenuRemote('107');">
+	<area shape="rect" coords="58,66,84,78" title="subtitle" onclick="pressMenuRemote('370');">
 	<area shape="rect" coords="24,65,51,78" title="startTeletext" onclick="pressMenuRemote(388);">
 	<area shape="rect" coords="90,66,117,78" title="ZoomInOut" onclick="pressMenuRemote(372);">
-	<area shape="rect" coords="24,86,51,100" id ="393" title="videoaltlast" onclick="pressMenuRemote('393');">
+	<area shape="rect" coords="24,86,51,100" title="videoaltlast" onclick="pressMenuRemote('393');">
 	<area shape="rect" coords="58,86,84,100" title="showMediaPlayer" onclick="pressMenuRemote('395');">
 	<area shape="rect" coords="90,86,117,100" title="openTimerList" onclick="pressMenuRemote(362);">
 
-	<area shape="rect" coords="24,110,50,130" id ="115" title="volume up" onclick="pressMenuRemote('115');">
-	<area shape="rect" coords="24,145,50,160" id ="114" title="volume down" onclick="pressMenuRemote('114');">
+	<area shape="rect" coords="24,110,50,130" title="volume up" onclick="pressMenuRemote('115');">
+	<area shape="rect" coords="24,145,50,160" title="volume down" onclick="pressMenuRemote('114');">
 
 	<area shape="rect" coords="58,112,82,130" title="EPGPressed" onclick="pressMenuRemote(365);">
-	<area shape="rect" coords="58,142,82,160" id ="392" title="audio" onclick="pressMenuRemote('392');">
+	<area shape="rect" coords="58,142,82,160" title="audio" onclick="pressMenuRemote('392');">
 
-	<area shape="rect" coords="90,110,118,130" id ="402" title="channelup" onclick="pressMenuRemote('402');">
-	<area shape="rect" coords="90,140,118,160" id ="403" title="channeldown" onclick="pressMenuRemote('403');">
+	<area shape="rect" coords="90,110,118,130" title="channelup" onclick="pressMenuRemote('402');">
+	<area shape="rect" coords="90,140,118,160" title="channeldown" onclick="pressMenuRemote('403');">
 
 
-	<area shape="circle" coords="32,181,16" id ="139" title="menu" onclick="pressMenuRemote('139');">
-	<area shape="circle" coords="108,181,16" id ="174" title="exit" onclick="pressMenuRemote('174');">
+	<area shape="circle" coords="32,181,16" title="menu" onclick="pressMenuRemote('139');">
+	<area shape="circle" coords="108,181,16" title="exit" onclick="pressMenuRemote('174');">
 
 	<area shape="circle" coords="32,245,16" title="openSatellites" onclick="pressMenuRemote(381);">
 
-	<area shape="circle" coords="70,187,16" id ="103" title="up" onclick="pressMenuRemote('103');">
-	<area shape="circle" coords="70,238,16" id ="108" title="down" onclick="pressMenuRemote('108');">
-	<area shape="circle" coords="46,212,16" id ="105" title="left" onclick="pressMenuRemote('105');">
-	<area shape="circle" coords="96,212,16" id ="106" title="right" onclick="pressMenuRemote('106');">
-	<area shape="circle" coords="72,213,20" id ="352" title="OK" onclick="pressMenuRemote('352');">
+	<area shape="circle" coords="70,187,16" title="up" onclick="pressMenuRemote('103');">
+	<area shape="circle" coords="70,238,16" title="down" onclick="pressMenuRemote('108');">
+	<area shape="circle" coords="46,212,16" title="left" onclick="pressMenuRemote('105');">
+	<area shape="circle" coords="96,212,16" title="right" onclick="pressMenuRemote('106');">
+	<area shape="circle" coords="72,213,20" title="OK" onclick="pressMenuRemote('352');">
 
 	<area shape="rect" coords="24,18,48,31" title="mute" onclick="pressMenuRemote('113');">
-	<area shape="rect" coords="96,15,116,34" id ="116" title="Power" onclick="pressMenuRemote('116');">
+	<area shape="rect" coords="96,15,116,34" title="Power" onclick="pressMenuRemote('116');">
 
 
-	<area shape="rect" coords="23,260,52,278" id ="2" title="1" onclick="pressMenuRemote('2');">
-	<area shape="rect" coords="58,260,83,278" id ="3" title="2" onclick="pressMenuRemote('3');">
-	<area shape="rect" coords="91,260,118,278" id ="4" title="3" onclick="pressMenuRemote('4');">
-	<area shape="rect" coords="23,287,52,307" id ="5" title="4" onclick="pressMenuRemote('5');">
-	<area shape="rect" coords="58,287,83,307" id ="6" title="5" onclick="pressMenuRemote('6');">
-	<area shape="rect" coords="91,287,118,307" id ="7" title="6" onclick="pressMenuRemote('7');">
-	<area shape="rect" coords="23,318,52,336" id ="8" title="7" onclick="pressMenuRemote('8');">
-	<area shape="rect" coords="58,318,83,336" id ="9" title="8" onclick="pressMenuRemote('9');">
-	<area shape="rect" coords="91,318,118,336" id ="10" title="9" onclick="pressMenuRemote('10');">
-	<area shape="rect" coords="58,346,83,363" id ="11" title="0" onclick="pressMenuRemote('11');">
+	<area shape="rect" coords="23,260,52,278" title="1" onclick="pressMenuRemote('2');">
+	<area shape="rect" coords="58,260,83,278" title="2" onclick="pressMenuRemote('3');">
+	<area shape="rect" coords="91,260,118,278" title="3" onclick="pressMenuRemote('4');">
+	<area shape="rect" coords="23,287,52,307" title="4" onclick="pressMenuRemote('5');">
+	<area shape="rect" coords="58,287,83,307" title="5" onclick="pressMenuRemote('6');">
+	<area shape="rect" coords="91,287,118,307" title="6" onclick="pressMenuRemote('7');">
+	<area shape="rect" coords="23,318,52,336" title="7" onclick="pressMenuRemote('8');">
+	<area shape="rect" coords="58,318,83,336" title="8" onclick="pressMenuRemote('9');">
+	<area shape="rect" coords="91,318,118,336" title="9" onclick="pressMenuRemote('10');">
+	<area shape="rect" coords="58,346,83,363" title="0" onclick="pressMenuRemote('11');">
 
-	<area shape="rect" coords="23,346,52,363" id ="412" title="previous" onclick="pressMenuRemote('412');">
-	<area shape="rect" coords="91,346,118,363" id ="407" title="next" onclick="pressMenuRemote('407');">
+	<area shape="rect" coords="23,346,52,363" title="previous" onclick="pressMenuRemote('412');">
+	<area shape="rect" coords="91,346,118,363" title="next" onclick="pressMenuRemote('407');">
 
-	<area shape="rect" coords="23,375,42,393" id ="398" title="red" onclick="pressMenuRemote('398');">
-	<area shape="rect" coords="50,375,69,393" id ="399" title="green" onclick="pressMenuRemote('399');">
-	<area shape="rect" coords="76,375,93,393" id ="400" title="yellow" onclick="pressMenuRemote('400');">
-	<area shape="rect" coords="100,375,119,393" id ="401" title="blue" onclick="pressMenuRemote('401');">
+	<area shape="rect" coords="23,375,42,393" title="red" onclick="pressMenuRemote('398');">
+	<area shape="rect" coords="50,375,69,393" title="green" onclick="pressMenuRemote('399');">
+	<area shape="rect" coords="76,375,93,393" title="yellow" onclick="pressMenuRemote('400');">
+	<area shape="rect" coords="100,375,119,393" title="blue" onclick="pressMenuRemote('401');">
 
 	<area shape="rect" coords="98,62,118,72" title="mute" onclick="pressMenuRemote('113');">
-	<area shape="rect" coords="96,15,116,34" id ="116" title="Power" onclick="pressMenuRemote('116');">
-	<area shape="rect" coords="24,65,50,78" id ="388" title="text" onclick="pressMenuRemote('388');">
+	<area shape="rect" coords="96,15,116,34" title="Power" onclick="pressMenuRemote('116');">
+	<area shape="rect" coords="24,65,50,78" title="text" onclick="pressMenuRemote('388');">
 
 	<area shape="circle" coords="33,280,20" title="openSatellites" onclick="pressMenuRemote(381);">
 
@@ -65,13 +65,13 @@
 	<area shape="rect" coords="76,424,93,440" title="timeshiftStop" onclick="pressMenuRemote(128);">
 
 	<!-- Fastforward, rewind -->
-	<area shape="rect" coords="23,400,42,416" id ="168" title="rewind" onclick="pressMenuRemote('168');">
-	<area shape="rect" coords="50,400,69,416" id ="207" title="play" onclick="pressMenuRemote('207');">
-	<area shape="rect" coords="75,400,94,416" id ="119" title="pause" onclick="pressMenuRemote('119');">
-	<area shape="rect" coords="100,400,118,416" id ="208" title="forward" onclick="pressMenuRemote('208');">
+	<area shape="rect" coords="23,400,42,416" title="rewind" onclick="pressMenuRemote('168');">
+	<area shape="rect" coords="50,400,69,416" title="play" onclick="pressMenuRemote('207');">
+	<area shape="rect" coords="75,400,94,416" title="pause" onclick="pressMenuRemote('119');">
+	<area shape="rect" coords="100,400,118,416" title="forward" onclick="pressMenuRemote('208');">
 
 	<!-- Key Radio, and Tv -->
 	<area shape="rect" coords="100,424,118,440" title="radio" onclick="pressMenuRemote(385);">
 	<area shape="rect" coords="23,424,42,440" title="tv" onclick="pressMenuRemote(377);">
-	<area shape="rect" coords="50,424,69,440" id ="167" title="record" onclick="pressMenuRemote('167');">
+	<area shape="rect" coords="50,424,69,440" title="record" onclick="pressMenuRemote('167');">
 </map>

--- a/BoxBranding/remotes/iqon1/remote.html
+++ b/BoxBranding/remotes/iqon1/remote.html
@@ -1,40 +1,40 @@
 <img border='0' src='/static/remotes/iqon1/rc.png' usemap='#map' >
 <map name="map">
 	<area shape="rect" coords="14,19,39,33" title="mute" onclick="pressMenuRemote('113');">
-	<area shape="rect" coords="87,16,107,35" id ="116" title="Power" onclick="pressMenuRemote('116');">
-	<area shape="rect" coords="14,65,40,79" id ="388" title="text" onclick="pressMenuRemote('388');">
-	<area shape="rect" coords="47,66,73,79" id ="370" title="subtitle" onclick="pressMenuRemote('370');">
-	<area shape="rect" coords="47,44,74,59" id ="172" title="home" onclick="pressMenuRemote('172');">
-	<area shape="rect" coords="80,44,104,59" id ="107" title="end" onclick="pressMenuRemote('107');">
+	<area shape="rect" coords="87,16,107,35" title="Power" onclick="pressMenuRemote('116');">
+	<area shape="rect" coords="14,65,40,79" title="text" onclick="pressMenuRemote('388');">
+	<area shape="rect" coords="47,66,73,79" title="subtitle" onclick="pressMenuRemote('370');">
+	<area shape="rect" coords="47,44,74,59" title="home" onclick="pressMenuRemote('172');">
+	<area shape="rect" coords="80,44,104,59" title="end" onclick="pressMenuRemote('107');">
 
-	<area shape="rect" coords="13,258,40,279" id ="2" title="1" onclick="pressMenuRemote('2');">
-	<area shape="rect" coords="47,258,74,279" id ="3" title="2" onclick="pressMenuRemote('3');">
-	<area shape="rect" coords="81,258,109,279" id ="4" title="3" onclick="pressMenuRemote('4');">
-	<area shape="rect" coords="13,287,40,307" id ="5" title="4" onclick="pressMenuRemote('5');">
-	<area shape="rect" coords="47,287,74,307" id ="6" title="5" onclick="pressMenuRemote('6');">
-	<area shape="rect" coords="81,287,109,307" id ="7" title="6" onclick="pressMenuRemote('7');">
-	<area shape="rect" coords="13,315,40,337" id ="8" title="7" onclick="pressMenuRemote('8');">
-	<area shape="rect" coords="47,315,74,337" id ="9" title="8" onclick="pressMenuRemote('9');">
-	<area shape="rect" coords="81,315,109,337" id ="10" title="9" onclick="pressMenuRemote('10');">
-	<area shape="rect" coords="47,344,74,364" id ="11" title="0" onclick="pressMenuRemote('11');">
+	<area shape="rect" coords="13,258,40,279" title="1" onclick="pressMenuRemote('2');">
+	<area shape="rect" coords="47,258,74,279" title="2" onclick="pressMenuRemote('3');">
+	<area shape="rect" coords="81,258,109,279" title="3" onclick="pressMenuRemote('4');">
+	<area shape="rect" coords="13,287,40,307" title="4" onclick="pressMenuRemote('5');">
+	<area shape="rect" coords="47,287,74,307" title="5" onclick="pressMenuRemote('6');">
+	<area shape="rect" coords="81,287,109,307" title="6" onclick="pressMenuRemote('7');">
+	<area shape="rect" coords="13,315,40,337" title="7" onclick="pressMenuRemote('8');">
+	<area shape="rect" coords="47,315,74,337" title="8" onclick="pressMenuRemote('9');">
+	<area shape="rect" coords="81,315,109,337" title="9" onclick="pressMenuRemote('10');">
+	<area shape="rect" coords="47,344,74,364" title="0" onclick="pressMenuRemote('11');">
 
 	<!-- Added Key -->
 	<!--<area shape="rect" coords="96,95,118,107" title="Lan" onclick="pressMenuRemote(59);">-->
-	<area shape="circle" coords="98,179,10" id ="174" title="exit" onclick="pressMenuRemote('174');">
+	<area shape="circle" coords="98,179,10" title="exit" onclick="pressMenuRemote('174');">
 
-	<area shape="rect" coords="80,109,107,133" id ="402" title="channelup" onclick="pressMenuRemote('402');">
-	<area shape="rect" coords="80,137,107,162" id ="403" title="channeldown" onclick="pressMenuRemote('403');">
+	<area shape="rect" coords="80,109,107,133" title="channelup" onclick="pressMenuRemote('402');">
+	<area shape="rect" coords="80,137,107,162" title="channeldown" onclick="pressMenuRemote('403');">
 
-	<area shape="rect" coords="14,109,40,133" id ="115" title="volume up" onclick="pressMenuRemote('115');">
-	<area shape="rect" coords="14,137,40,162" id ="114" title="volume down" onclick="pressMenuRemote('114');">
+	<area shape="rect" coords="14,109,40,133" title="volume up" onclick="pressMenuRemote('115');">
+	<area shape="rect" coords="14,137,40,162" title="volume down" onclick="pressMenuRemote('114');">
 
-	<area shape="rect" coords="13,343,41,364" id ="412" title="previous" onclick="pressMenuRemote('412');">
-	<area shape="rect" coords="80,343,108,364" id ="407" title="next" onclick="pressMenuRemote('407');">
+	<area shape="rect" coords="13,343,41,364" title="previous" onclick="pressMenuRemote('412');">
+	<area shape="rect" coords="80,343,108,364" title="next" onclick="pressMenuRemote('407');">
 
-	<area shape="rect" coords="14,375,32,392" id ="398" title="red" onclick="pressMenuRemote('398');">
-	<area shape="rect" coords="38,375,57,392" id ="399" title="green" onclick="pressMenuRemote('399');">
-	<area shape="rect" coords="64,375,83,392" id ="400" title="yellow" onclick="pressMenuRemote('400');">
-	<area shape="rect" coords="89,375,108,392" id ="401" title="blue" onclick="pressMenuRemote('401');">
+	<area shape="rect" coords="14,375,32,392" title="red" onclick="pressMenuRemote('398');">
+	<area shape="rect" coords="38,375,57,392" title="green" onclick="pressMenuRemote('399');">
+	<area shape="rect" coords="64,375,83,392" title="yellow" onclick="pressMenuRemote('400');">
+	<area shape="rect" coords="89,375,108,392" title="blue" onclick="pressMenuRemote('401');">
 
 	<area shape="rect" coords="48,115,73,129" title="EPGPressed" onclick="pressMenuRemote(365);">
 	<area shape="circle" coords="22,244,10" title="openSatellites" onclick="pressMenuRemote(381);">
@@ -66,76 +66,76 @@
 
 	<!-- Rf modulator -->
 	<!--<area shape="rect" coords="98,114,116,124" title="showRFmod" onclick="pressMenuRemote(63);">-->
-	<area shape="circle" coords="99,244,10" id ="358" title="Info" onclick="pressMenuRemote('358');">
+	<area shape="circle" coords="99,244,10" title="Info" onclick="pressMenuRemote('358');">
 
-	<area shape="circle" coords="61,184,7" id ="103" title="up" onclick="pressMenuRemote('103');">
-	<area shape="circle" coords="61,238,7" id ="108" title="down" onclick="pressMenuRemote('108');">
-	<area shape="circle" coords="33,211,7" id ="105" title="left" onclick="pressMenuRemote('105');">
-	<area shape="circle" coords="86,211,7" id ="106" title="right" onclick="pressMenuRemote('106');">
+	<area shape="circle" coords="61,184,7" title="up" onclick="pressMenuRemote('103');">
+	<area shape="circle" coords="61,238,7" title="down" onclick="pressMenuRemote('108');">
+	<area shape="circle" coords="33,211,7" title="left" onclick="pressMenuRemote('105');">
+	<area shape="circle" coords="86,211,7" title="right" onclick="pressMenuRemote('106');">
 
-	<area shape="circle" coords="61,211,15" id ="352" title="OK" onclick="pressMenuRemote('352');">
-	<area shape="rect" coords="47,143,72,157" id ="392" title="audio" onclick="pressMenuRemote('392');">
+	<area shape="circle" coords="61,211,15" title="OK" onclick="pressMenuRemote('352');">
+	<area shape="rect" coords="47,143,72,157" title="audio" onclick="pressMenuRemote('392');">
 
-	<area shape="circle" coords="22,178,10" id ="139" title="menu" onclick="pressMenuRemote('139');">
-	<area shape="rect" coords="38,423,57,441" id ="167" title="record" onclick="pressMenuRemote('167');">
-	<area shape="rect" coords="13,86,40,100" id ="393" title="videoaltlast" onclick="pressMenuRemote('393');">
+	<area shape="circle" coords="22,178,10" title="menu" onclick="pressMenuRemote('139');">
+	<area shape="rect" coords="38,423,57,441" title="record" onclick="pressMenuRemote('167');">
+	<area shape="rect" coords="13,86,40,100" title="videoaltlast" onclick="pressMenuRemote('393');">
 
-	<area shape="rect" coords="13,44,40,59" id ="138" title="help" onclick="pressMenuRemote('138');">
+	<area shape="rect" coords="13,44,40,59" title="help" onclick="pressMenuRemote('138');">
 
-	<area shape="rect" coords="14,400,32,417" id ="168" title="rewind" onclick="pressMenuRemote('168');">
-	<area shape="rect" coords="38,400,58,417" id ="207" title="play" onclick="pressMenuRemote('207');">
-	<area shape="rect" coords="64,400,82,417" id ="119" title="pause" onclick="pressMenuRemote('119');">
-	<area shape="rect" coords="89,400,107,417" id ="208" title="forward" onclick="pressMenuRemote('208');">
-	<area shape="rect" coords="13,424,31,441" id ="377" title="tv" onclick="pressMenuRemote('377');">
+	<area shape="rect" coords="14,400,32,417" title="rewind" onclick="pressMenuRemote('168');">
+	<area shape="rect" coords="38,400,58,417" title="play" onclick="pressMenuRemote('207');">
+	<area shape="rect" coords="64,400,82,417" title="pause" onclick="pressMenuRemote('119');">
+	<area shape="rect" coords="89,400,107,417" title="forward" onclick="pressMenuRemote('208');">
+	<area shape="rect" coords="13,424,31,441" title="tv" onclick="pressMenuRemote('377');">
 
 
-	<area shape="rect" coords="63,424,82,440" id ="128" title="stop" onclick="pressMenuRemote('128');">
-	<area shape="circle" coords="90,424,107,440" id ="385" title="radio" onclick="pressMenuRemote('385');">
+	<area shape="rect" coords="63,424,82,440" title="stop" onclick="pressMenuRemote('128');">
+	<area shape="circle" coords="90,424,107,440" title="radio" onclick="pressMenuRemote('385');">
 </map>
 <!--
 	<area shape="circle" coords="33,28,15" title="mute" onclick="pressMenuRemote('113');">
-	<area shape="circle" coords="105,28,15" id ="116" title="Power" onclick="pressMenuRemote('116');">
-	<area shape="circle" coords="33,53,15" id ="388" title="text" onclick="pressMenuRemote('388');">
-	<area shape="circle" coords="58,53,15" id ="370" title="subtitle" onclick="pressMenuRemote('370');">
-	<area shape="circle" coords="82,53,15" id ="102" title="home" onclick="pressMenuRemote('102');">
-	<area shape="circle" coords="105,53,15" id ="107" title="end" onclick="pressMenuRemote('107');">
-	<area shape="circle" coords="38,79,15" id ="2" title="1" onclick="pressMenuRemote('2');">
-	<area shape="circle" coords="70,79,15" id ="3" title="2" onclick="pressMenuRemote('3');">
-	<area shape="circle" coords="102,79,15" id ="4" title="3" onclick="pressMenuRemote('4');">
-	<area shape="circle" coords="38,106,15" id ="5" title="4" onclick="pressMenuRemote('5');">
-	<area shape="circle" coords="70,106,15" id ="6" title="5" onclick="pressMenuRemote('6');">
-	<area shape="circle" coords="102,106,15" id ="7" title="6" onclick="pressMenuRemote('7');">
-	<area shape="circle" coords="38,133,15" id ="8" title="7" onclick="pressMenuRemote('8');">
-	<area shape="circle" coords="70,133,15" id ="9" title="8" onclick="pressMenuRemote('9');">
-	<area shape="circle" coords="102,133,15" id ="10" title="9" onclick="pressMenuRemote('10');">
-	<area shape="circle" coords="38,161,15" id ="412" title="previous" onclick="pressMenuRemote('412');">
-	<area shape="circle" coords="70,161,15" id ="11" title="0" onclick="pressMenuRemote('11');">
-	<area shape="circle" coords="102,161,15" id ="407" title="next" onclick="pressMenuRemote('407');">
-	<area shape="circle" coords="33,186,15" id ="398" title="red" onclick="pressMenuRemote('398');">
-	<area shape="circle" coords="58,186,15" id ="399" title="green" onclick="pressMenuRemote('399');">
-	<area shape="circle" coords="82,186,15" id ="400" title="yellow" onclick="pressMenuRemote('400');">
-	<area shape="circle" coords="105,186,15" id ="401" title="blue" onclick="pressMenuRemote('401');">
-	<area shape="circle" coords="70,213,15" id ="103" title="up" onclick="pressMenuRemote('103');">
-	<area shape="circle" coords="70,283,15" id ="108" title="down" onclick="pressMenuRemote('108');">
-	<area shape="circle" coords="35,248,15" id ="105" title="left" onclick="pressMenuRemote('105');">
-	<area shape="circle" coords="105,248,15" id ="106" title="right" onclick="pressMenuRemote('106');">
-	<area shape="circle" coords="70,248,20" id ="352" title="OK" onclick="pressMenuRemote('352');">
-	<area shape="circle" coords="40,307,15" id ="115" title="volume up" onclick="pressMenuRemote('115');">
-	<area shape="circle" coords="40,338,13" id ="114" title="volume down" onclick="pressMenuRemote('114');">
-	<area shape="circle" coords="70,310,15" id ="174" title="exit" onclick="pressMenuRemote('174');">
-	<area shape="circle" coords="70,334,15" id ="358" title="epg" onclick="pressMenuRemote('358');">
-	<area shape="circle" coords="99,307,15" id ="402" title="channelup" onclick="pressMenuRemote('402');">
-	<area shape="circle" coords="99,338,15" id ="403" title="channeldown" onclick="pressMenuRemote('403');">
-	<area shape="circle" coords="36,362,15" id ="139" title="menu" onclick="pressMenuRemote('139');">
-	<area shape="circle" coords="59,362,15" id ="393" title="videoaltlast" onclick="pressMenuRemote('393');">
-	<area shape="circle" coords="81,362,15" id ="392" title="audio" onclick="pressMenuRemote('392');">
-	<area shape="circle" coords="104,362,15" id ="138" title="help" onclick="pressMenuRemote('138');">
-	<area shape="circle" coords="36,383,15" id ="168" title="rewind" onclick="pressMenuRemote('168');">
-	<area shape="circle" coords="59,383,15" id ="207" title="play" onclick="pressMenuRemote('207');">
-	<area shape="circle" coords="81,383,15" id ="119" title="pause" onclick="pressMenuRemote('119');">
-	<area shape="circle" coords="104,383,15" id ="208" title="forward" onclick="pressMenuRemote('208');">
-	<area shape="circle" coords="36,405,15" id ="377" title="tv" onclick="pressMenuRemote('377');">
-	<area shape="circle" coords="59,405,15" id ="167" title="record" onclick="pressMenuRemote('167');">
-	<area shape="circle" coords="81,405,15" id ="128" title="stop" onclick="pressMenuRemote('128');">
-	<area shape="circle" coords="104,405,15" id ="385" title="radio" onclick="pressMenuRemote('385');">
+	<area shape="circle" coords="105,28,15" title="Power" onclick="pressMenuRemote('116');">
+	<area shape="circle" coords="33,53,15" title="text" onclick="pressMenuRemote('388');">
+	<area shape="circle" coords="58,53,15" title="subtitle" onclick="pressMenuRemote('370');">
+	<area shape="circle" coords="82,53,15" title="home" onclick="pressMenuRemote('102');">
+	<area shape="circle" coords="105,53,15" title="end" onclick="pressMenuRemote('107');">
+	<area shape="circle" coords="38,79,15" title="1" onclick="pressMenuRemote('2');">
+	<area shape="circle" coords="70,79,15" title="2" onclick="pressMenuRemote('3');">
+	<area shape="circle" coords="102,79,15" title="3" onclick="pressMenuRemote('4');">
+	<area shape="circle" coords="38,106,15" title="4" onclick="pressMenuRemote('5');">
+	<area shape="circle" coords="70,106,15" title="5" onclick="pressMenuRemote('6');">
+	<area shape="circle" coords="102,106,15" title="6" onclick="pressMenuRemote('7');">
+	<area shape="circle" coords="38,133,15" title="7" onclick="pressMenuRemote('8');">
+	<area shape="circle" coords="70,133,15" title="8" onclick="pressMenuRemote('9');">
+	<area shape="circle" coords="102,133,15" title="9" onclick="pressMenuRemote('10');">
+	<area shape="circle" coords="38,161,15" title="previous" onclick="pressMenuRemote('412');">
+	<area shape="circle" coords="70,161,15" title="0" onclick="pressMenuRemote('11');">
+	<area shape="circle" coords="102,161,15" title="next" onclick="pressMenuRemote('407');">
+	<area shape="circle" coords="33,186,15" title="red" onclick="pressMenuRemote('398');">
+	<area shape="circle" coords="58,186,15" title="green" onclick="pressMenuRemote('399');">
+	<area shape="circle" coords="82,186,15" title="yellow" onclick="pressMenuRemote('400');">
+	<area shape="circle" coords="105,186,15" title="blue" onclick="pressMenuRemote('401');">
+	<area shape="circle" coords="70,213,15" title="up" onclick="pressMenuRemote('103');">
+	<area shape="circle" coords="70,283,15" title="down" onclick="pressMenuRemote('108');">
+	<area shape="circle" coords="35,248,15" title="left" onclick="pressMenuRemote('105');">
+	<area shape="circle" coords="105,248,15" title="right" onclick="pressMenuRemote('106');">
+	<area shape="circle" coords="70,248,20" title="OK" onclick="pressMenuRemote('352');">
+	<area shape="circle" coords="40,307,15" title="volume up" onclick="pressMenuRemote('115');">
+	<area shape="circle" coords="40,338,13" title="volume down" onclick="pressMenuRemote('114');">
+	<area shape="circle" coords="70,310,15" title="exit" onclick="pressMenuRemote('174');">
+	<area shape="circle" coords="70,334,15" title="epg" onclick="pressMenuRemote('358');">
+	<area shape="circle" coords="99,307,15" title="channelup" onclick="pressMenuRemote('402');">
+	<area shape="circle" coords="99,338,15" title="channeldown" onclick="pressMenuRemote('403');">
+	<area shape="circle" coords="36,362,15" title="menu" onclick="pressMenuRemote('139');">
+	<area shape="circle" coords="59,362,15" title="videoaltlast" onclick="pressMenuRemote('393');">
+	<area shape="circle" coords="81,362,15" title="audio" onclick="pressMenuRemote('392');">
+	<area shape="circle" coords="104,362,15" title="help" onclick="pressMenuRemote('138');">
+	<area shape="circle" coords="36,383,15" title="rewind" onclick="pressMenuRemote('168');">
+	<area shape="circle" coords="59,383,15" title="play" onclick="pressMenuRemote('207');">
+	<area shape="circle" coords="81,383,15" title="pause" onclick="pressMenuRemote('119');">
+	<area shape="circle" coords="104,383,15" title="forward" onclick="pressMenuRemote('208');">
+	<area shape="circle" coords="36,405,15" title="tv" onclick="pressMenuRemote('377');">
+	<area shape="circle" coords="59,405,15" title="record" onclick="pressMenuRemote('167');">
+	<area shape="circle" coords="81,405,15" title="stop" onclick="pressMenuRemote('128');">
+	<area shape="circle" coords="104,405,15" title="radio" onclick="pressMenuRemote('385');">
 	-->

--- a/BoxBranding/remotes/iqon2/remote.html
+++ b/BoxBranding/remotes/iqon2/remote.html
@@ -1,40 +1,40 @@
 <img border='0' src='/static/remotes/iqon2/rc.png' usemap='#map' >
 <map name="map">
 	<area shape="rect" coords="92,19,105,32" title="mute" onclick="pressMenuRemote('113');">
-	<area shape="rect" coords="33,18,50,35" id ="116" title="Power" onclick="pressMenuRemote('116');">
-	<area shape="rect" coords="50,248,65,256" id ="388" title="text" onclick="pressMenuRemote('388');">
-	<area shape="rect" coords="73,248,88,256" id ="370" title="subtitle" onclick="pressMenuRemote('370');">
-	<area shape="rect" coords="60,46,79,58" id ="172" title="home" onclick="pressMenuRemote('172');">
-	<area shape="rect" coords="88,46,109,58" id ="107" title="end" onclick="pressMenuRemote('107');">
+	<area shape="rect" coords="33,18,50,35" title="Power" onclick="pressMenuRemote('116');">
+	<area shape="rect" coords="50,248,65,256" title="text" onclick="pressMenuRemote('388');">
+	<area shape="rect" coords="73,248,88,256" title="subtitle" onclick="pressMenuRemote('370');">
+	<area shape="rect" coords="60,46,79,58" title="home" onclick="pressMenuRemote('172');">
+	<area shape="rect" coords="88,46,109,58" title="end" onclick="pressMenuRemote('107');">
 
-	<area shape="rect" coords="32,87,50,100" id ="2" title="1" onclick="pressMenuRemote('2');">
-	<area shape="rect" coords="62,87,79,100" id ="3" title="2" onclick="pressMenuRemote('3');">
-	<area shape="rect" coords="89,87,107,100" id ="4" title="3" onclick="pressMenuRemote('4');">
-	<area shape="rect" coords="32,109,50,123" id ="5" title="4" onclick="pressMenuRemote('5');">
-	<area shape="rect" coords="62,109,79,123" id ="6" title="5" onclick="pressMenuRemote('6');">
-	<area shape="rect" coords="89,109,107,123" id ="7" title="6" onclick="pressMenuRemote('7');">
-	<area shape="rect" coords="32,132,50,146" id ="8" title="7" onclick="pressMenuRemote('8');">
-	<area shape="rect" coords="62,132,79,146" id ="9" title="8" onclick="pressMenuRemote('9');">
-	<area shape="rect" coords="89,132,107,146" id ="10" title="9" onclick="pressMenuRemote('10');">
-	<area shape="rect" coords="62,156,79,170" id ="11" title="0" onclick="pressMenuRemote('11');">
+	<area shape="rect" coords="32,87,50,100" title="1" onclick="pressMenuRemote('2');">
+	<area shape="rect" coords="62,87,79,100" title="2" onclick="pressMenuRemote('3');">
+	<area shape="rect" coords="89,87,107,100" title="3" onclick="pressMenuRemote('4');">
+	<area shape="rect" coords="32,109,50,123" title="4" onclick="pressMenuRemote('5');">
+	<area shape="rect" coords="62,109,79,123" title="5" onclick="pressMenuRemote('6');">
+	<area shape="rect" coords="89,109,107,123" title="6" onclick="pressMenuRemote('7');">
+	<area shape="rect" coords="32,132,50,146" title="7" onclick="pressMenuRemote('8');">
+	<area shape="rect" coords="62,132,79,146" title="8" onclick="pressMenuRemote('9');">
+	<area shape="rect" coords="89,132,107,146" title="9" onclick="pressMenuRemote('10');">
+	<area shape="rect" coords="62,156,79,170" title="0" onclick="pressMenuRemote('11');">
 
 	<!-- Added Key -->
 	<area shape="rect" coords="89,68,107,78" title="Lan" onclick="pressMenuRemote('376');">
-	<area shape="circle" coords="106,275,8" id ="174" title="exit" onclick="pressMenuRemote('174');">
+	<area shape="circle" coords="106,275,8" title="exit" onclick="pressMenuRemote('174');">
 
-	<area shape="rect" coords="91,183,109,203" id ="402" title="channelup" onclick="pressMenuRemote('402');">
-	<area shape="rect" coords="91,214,109,233" id ="403" title="channeldown" onclick="pressMenuRemote('403');">
+	<area shape="rect" coords="91,183,109,203" title="channelup" onclick="pressMenuRemote('402');">
+	<area shape="rect" coords="91,214,109,233" title="channeldown" onclick="pressMenuRemote('403');">
 
-	<area shape="rect" coords="29,183,47,203" id ="115" title="volume up" onclick="pressMenuRemote('115');">
-	<area shape="rect" coords="29,214,47,233" id ="114" title="volume down" onclick="pressMenuRemote('114');">
+	<area shape="rect" coords="29,183,47,203" title="volume up" onclick="pressMenuRemote('115');">
+	<area shape="rect" coords="29,214,47,233" title="volume down" onclick="pressMenuRemote('114');">
 
-	<area shape="rect" coords="29,153,52,171" id ="412" title="previous" onclick="pressMenuRemote('412');">
-	<area shape="rect" coords="86,155,109,171" id ="407" title="next" onclick="pressMenuRemote('407');">
+	<area shape="rect" coords="29,153,52,171" title="previous" onclick="pressMenuRemote('412');">
+	<area shape="rect" coords="86,155,109,171" title="next" onclick="pressMenuRemote('407');">
 
-	<area shape="rect" coords="27,361,42,371" id ="398" title="red" onclick="pressMenuRemote('398');">
-	<area shape="rect" coords="50,361,66,371" id ="399" title="green" onclick="pressMenuRemote('399');">
-	<area shape="rect" coords="71,361,89,371" id ="400" title="yellow" onclick="pressMenuRemote('400');">
-	<area shape="rect" coords="95,361,112,371" id ="401" title="blue" onclick="pressMenuRemote('401');">
+	<area shape="rect" coords="27,361,42,371" title="red" onclick="pressMenuRemote('398');">
+	<area shape="rect" coords="50,361,66,371" title="green" onclick="pressMenuRemote('399');">
+	<area shape="rect" coords="71,361,89,371" title="yellow" onclick="pressMenuRemote('400');">
+	<area shape="rect" coords="95,361,112,371" title="blue" onclick="pressMenuRemote('401');">
 
 	<area shape="circle" coords="69,194,8" title="EPGPressed" onclick="pressMenuRemote(365);">
 	<area shape="circle" coords="33,344,8" title="openSatellites" onclick="pressMenuRemote(381);">
@@ -67,79 +67,79 @@
 	<!-- Rf modulator -->
 	<area shape="rect" coords="59,65,80,79" title="showRFmod" onclick="pressMenuRemote('371');">
 
-	<area shape="circle" coords="69,282,8" id ="103" title="up" onclick="pressMenuRemote('103');">
-	<area shape="circle" coords="69,336,8" id ="108" title="down" onclick="pressMenuRemote('108');">
-	<area shape="circle" coords="41,309,8" id ="105" title="left" onclick="pressMenuRemote('105');">
-	<area shape="circle" coords="96,309,8" id ="106" title="right" onclick="pressMenuRemote('106');">
+	<area shape="circle" coords="69,282,8" title="up" onclick="pressMenuRemote('103');">
+	<area shape="circle" coords="69,336,8" title="down" onclick="pressMenuRemote('108');">
+	<area shape="circle" coords="41,309,8" title="left" onclick="pressMenuRemote('105');">
+	<area shape="circle" coords="96,309,8" title="right" onclick="pressMenuRemote('106');">
 
-	<area shape="circle" coords="69,309,12" id ="352" title="OK" onclick="pressMenuRemote('352');">
-	<area shape="circle" coords="35,252,8" id ="392" title="audio" onclick="pressMenuRemote('392');">
+	<area shape="circle" coords="69,309,12" title="OK" onclick="pressMenuRemote('352');">
+	<area shape="circle" coords="35,252,8" title="audio" onclick="pressMenuRemote('392');">
 
-	<area shape="circle" coords="32,275,8" id ="139" title="menu" onclick="pressMenuRemote('139');">
-	<area shape="rect" coords="50,442,64,432" id ="167" title="record" onclick="pressMenuRemote('167');">
-	<area shape="rect" coords="26,385,43,394" id ="393" title="videoaltlast" onclick="pressMenuRemote('393');">
+	<area shape="circle" coords="32,275,8" title="menu" onclick="pressMenuRemote('139');">
+	<area shape="rect" coords="50,442,64,432" title="record" onclick="pressMenuRemote('167');">
+	<area shape="rect" coords="26,385,43,394" title="videoaltlast" onclick="pressMenuRemote('393');">
 
-	<area shape="rect" coords="31,48,49,58" id ="138" title="help" onclick="pressMenuRemote('138');">
+	<area shape="rect" coords="31,48,49,58" title="help" onclick="pressMenuRemote('138');">
 
-	<area shape="rect" coords="27,403,42,413" id ="168" title="rewind" onclick="pressMenuRemote('168');">
-	<area shape="rect" coords="49,403,65,413" id ="207" title="play" onclick="pressMenuRemote('207');">
-	<area shape="rect" coords="72,404,88,413" id ="119" title="pause" onclick="pressMenuRemote('119');">
-	<area shape="rect" coords="95,404,110,413" id ="208" title="forward" onclick="pressMenuRemote('208');">
-	<area shape="rect" coords="27,421,43,431" id ="377" title="tv" onclick="pressMenuRemote('377');">
+	<area shape="rect" coords="27,403,42,413" title="rewind" onclick="pressMenuRemote('168');">
+	<area shape="rect" coords="49,403,65,413" title="play" onclick="pressMenuRemote('207');">
+	<area shape="rect" coords="72,404,88,413" title="pause" onclick="pressMenuRemote('119');">
+	<area shape="rect" coords="95,404,110,413" title="forward" onclick="pressMenuRemote('208');">
+	<area shape="rect" coords="27,421,43,431" title="tv" onclick="pressMenuRemote('377');">
 
 
-	<area shape="rect" coords="72,421,88,431" id ="128" title="stop" onclick="pressMenuRemote('128');">
-	<area shape="rect" coords="95,422,110,430" id ="385" title="radio" onclick="pressMenuRemote('385');">
+	<area shape="rect" coords="72,421,88,431" title="stop" onclick="pressMenuRemote('128');">
+	<area shape="rect" coords="95,422,110,430" title="radio" onclick="pressMenuRemote('385');">
 
-	<area shape="circle" coords="69,224,10" id ="358" title="Info" onclick="pressMenuRemote('358');">
-	<area shape="rect" coords="98,336,114,351" id ="406" title="prov" onclick="pressMenuRemote('406');">
-	<area shape="rect" coords="71,383,89,395" id ="394" title="ytube" onclick="pressMenuRemote('394');">
-	<area shape="rect" coords="94,384,112,395" id ="375" title="pip" onclick="pressMenuRemote('375');">
+	<area shape="circle" coords="69,224,10" title="Info" onclick="pressMenuRemote('358');">
+	<area shape="rect" coords="98,336,114,351" title="prov" onclick="pressMenuRemote('406');">
+	<area shape="rect" coords="71,383,89,395" title="ytube" onclick="pressMenuRemote('394');">
+	<area shape="rect" coords="94,384,112,395" title="pip" onclick="pressMenuRemote('375');">
 </map>
 <!--
 	<area shape="circle" coords="33,28,15" title="mute" onclick="pressMenuRemote('113');">
-	<area shape="circle" coords="105,28,15" id ="116" title="Power" onclick="pressMenuRemote('116');">
-	<area shape="circle" coords="33,53,15" id ="388" title="text" onclick="pressMenuRemote('388');">
-	<area shape="circle" coords="58,53,15" id ="370" title="subtitle" onclick="pressMenuRemote('370');">
-	<area shape="circle" coords="82,53,15" id ="102" title="home" onclick="pressMenuRemote('102');">
-	<area shape="circle" coords="105,53,15" id ="107" title="end" onclick="pressMenuRemote('107');">
-	<area shape="circle" coords="38,79,15" id ="2" title="1" onclick="pressMenuRemote('2');">
-	<area shape="circle" coords="70,79,15" id ="3" title="2" onclick="pressMenuRemote('3');">
-	<area shape="circle" coords="102,79,15" id ="4" title="3" onclick="pressMenuRemote('4');">
-	<area shape="circle" coords="38,106,15" id ="5" title="4" onclick="pressMenuRemote('5');">
-	<area shape="circle" coords="70,106,15" id ="6" title="5" onclick="pressMenuRemote('6');">
-	<area shape="circle" coords="102,106,15" id ="7" title="6" onclick="pressMenuRemote('7');">
-	<area shape="circle" coords="38,133,15" id ="8" title="7" onclick="pressMenuRemote('8');">
-	<area shape="circle" coords="70,133,15" id ="9" title="8" onclick="pressMenuRemote('9');">
-	<area shape="circle" coords="102,133,15" id ="10" title="9" onclick="pressMenuRemote('10');">
-	<area shape="circle" coords="38,161,15" id ="412" title="previous" onclick="pressMenuRemote('412');">
-	<area shape="circle" coords="70,161,15" id ="11" title="0" onclick="pressMenuRemote('11');">
-	<area shape="circle" coords="102,161,15" id ="407" title="next" onclick="pressMenuRemote('407');">
-	<area shape="circle" coords="33,186,15" id ="398" title="red" onclick="pressMenuRemote('398');">
-	<area shape="circle" coords="58,186,15" id ="399" title="green" onclick="pressMenuRemote('399');">
-	<area shape="circle" coords="82,186,15" id ="400" title="yellow" onclick="pressMenuRemote('400');">
-	<area shape="circle" coords="105,186,15" id ="401" title="blue" onclick="pressMenuRemote('401');">
-	<area shape="circle" coords="70,213,15" id ="103" title="up" onclick="pressMenuRemote('103');">
-	<area shape="circle" coords="70,283,15" id ="108" title="down" onclick="pressMenuRemote('108');">
-	<area shape="circle" coords="35,248,15" id ="105" title="left" onclick="pressMenuRemote('105');">
-	<area shape="circle" coords="105,248,15" id ="106" title="right" onclick="pressMenuRemote('106');">
-	<area shape="circle" coords="70,248,20" id ="352" title="OK" onclick="pressMenuRemote('352');">
-	<area shape="circle" coords="40,307,15" id ="115" title="volume up" onclick="pressMenuRemote('115');">
-	<area shape="circle" coords="40,338,13" id ="114" title="volume down" onclick="pressMenuRemote('114');">
-	<area shape="circle" coords="70,310,15" id ="174" title="exit" onclick="pressMenuRemote('174');">
-	<area shape="circle" coords="70,334,15" id ="358" title="epg" onclick="pressMenuRemote('358');">
-	<area shape="circle" coords="99,307,15" id ="402" title="channelup" onclick="pressMenuRemote('402');">
-	<area shape="circle" coords="99,338,15" id ="403" title="channeldown" onclick="pressMenuRemote('403');">
-	<area shape="circle" coords="36,362,15" id ="139" title="menu" onclick="pressMenuRemote('139');">
-	<area shape="circle" coords="59,362,15" id ="393" title="videoaltlast" onclick="pressMenuRemote('393');">
-	<area shape="circle" coords="81,362,15" id ="392" title="audio" onclick="pressMenuRemote('392');">
-	<area shape="circle" coords="104,362,15" id ="138" title="help" onclick="pressMenuRemote('138');">
-	<area shape="circle" coords="36,383,15" id ="168" title="rewind" onclick="pressMenuRemote('168');">
-	<area shape="circle" coords="59,383,15" id ="207" title="play" onclick="pressMenuRemote('207');">
-	<area shape="circle" coords="81,383,15" id ="119" title="pause" onclick="pressMenuRemote('119');">
-	<area shape="circle" coords="104,383,15" id ="208" title="forward" onclick="pressMenuRemote('208');">
-	<area shape="circle" coords="36,405,15" id ="377" title="tv" onclick="pressMenuRemote('377');">
-	<area shape="circle" coords="59,405,15" id ="167" title="record" onclick="pressMenuRemote('167');">
-	<area shape="circle" coords="81,405,15" id ="128" title="stop" onclick="pressMenuRemote('128');">
-	<area shape="circle" coords="104,405,15" id ="385" title="radio" onclick="pressMenuRemote('385');">
+	<area shape="circle" coords="105,28,15" title="Power" onclick="pressMenuRemote('116');">
+	<area shape="circle" coords="33,53,15" title="text" onclick="pressMenuRemote('388');">
+	<area shape="circle" coords="58,53,15" title="subtitle" onclick="pressMenuRemote('370');">
+	<area shape="circle" coords="82,53,15" title="home" onclick="pressMenuRemote('102');">
+	<area shape="circle" coords="105,53,15" title="end" onclick="pressMenuRemote('107');">
+	<area shape="circle" coords="38,79,15" title="1" onclick="pressMenuRemote('2');">
+	<area shape="circle" coords="70,79,15" title="2" onclick="pressMenuRemote('3');">
+	<area shape="circle" coords="102,79,15" title="3" onclick="pressMenuRemote('4');">
+	<area shape="circle" coords="38,106,15" title="4" onclick="pressMenuRemote('5');">
+	<area shape="circle" coords="70,106,15" title="5" onclick="pressMenuRemote('6');">
+	<area shape="circle" coords="102,106,15" title="6" onclick="pressMenuRemote('7');">
+	<area shape="circle" coords="38,133,15" title="7" onclick="pressMenuRemote('8');">
+	<area shape="circle" coords="70,133,15" title="8" onclick="pressMenuRemote('9');">
+	<area shape="circle" coords="102,133,15" title="9" onclick="pressMenuRemote('10');">
+	<area shape="circle" coords="38,161,15" title="previous" onclick="pressMenuRemote('412');">
+	<area shape="circle" coords="70,161,15" title="0" onclick="pressMenuRemote('11');">
+	<area shape="circle" coords="102,161,15" title="next" onclick="pressMenuRemote('407');">
+	<area shape="circle" coords="33,186,15" title="red" onclick="pressMenuRemote('398');">
+	<area shape="circle" coords="58,186,15" title="green" onclick="pressMenuRemote('399');">
+	<area shape="circle" coords="82,186,15" title="yellow" onclick="pressMenuRemote('400');">
+	<area shape="circle" coords="105,186,15" title="blue" onclick="pressMenuRemote('401');">
+	<area shape="circle" coords="70,213,15" title="up" onclick="pressMenuRemote('103');">
+	<area shape="circle" coords="70,283,15" title="down" onclick="pressMenuRemote('108');">
+	<area shape="circle" coords="35,248,15" title="left" onclick="pressMenuRemote('105');">
+	<area shape="circle" coords="105,248,15" title="right" onclick="pressMenuRemote('106');">
+	<area shape="circle" coords="70,248,20" title="OK" onclick="pressMenuRemote('352');">
+	<area shape="circle" coords="40,307,15" title="volume up" onclick="pressMenuRemote('115');">
+	<area shape="circle" coords="40,338,13" title="volume down" onclick="pressMenuRemote('114');">
+	<area shape="circle" coords="70,310,15" title="exit" onclick="pressMenuRemote('174');">
+	<area shape="circle" coords="70,334,15" title="epg" onclick="pressMenuRemote('358');">
+	<area shape="circle" coords="99,307,15" title="channelup" onclick="pressMenuRemote('402');">
+	<area shape="circle" coords="99,338,15" title="channeldown" onclick="pressMenuRemote('403');">
+	<area shape="circle" coords="36,362,15" title="menu" onclick="pressMenuRemote('139');">
+	<area shape="circle" coords="59,362,15" title="videoaltlast" onclick="pressMenuRemote('393');">
+	<area shape="circle" coords="81,362,15" title="audio" onclick="pressMenuRemote('392');">
+	<area shape="circle" coords="104,362,15" title="help" onclick="pressMenuRemote('138');">
+	<area shape="circle" coords="36,383,15" title="rewind" onclick="pressMenuRemote('168');">
+	<area shape="circle" coords="59,383,15" title="play" onclick="pressMenuRemote('207');">
+	<area shape="circle" coords="81,383,15" title="pause" onclick="pressMenuRemote('119');">
+	<area shape="circle" coords="104,383,15" title="forward" onclick="pressMenuRemote('208');">
+	<area shape="circle" coords="36,405,15" title="tv" onclick="pressMenuRemote('377');">
+	<area shape="circle" coords="59,405,15" title="record" onclick="pressMenuRemote('167');">
+	<area shape="circle" coords="81,405,15" title="stop" onclick="pressMenuRemote('128');">
+	<area shape="circle" coords="104,405,15" title="radio" onclick="pressMenuRemote('385');">
 	-->

--- a/BoxBranding/remotes/iqon3/remote.html
+++ b/BoxBranding/remotes/iqon3/remote.html
@@ -1,69 +1,69 @@
 <img border='0' src='/static/remotes/iqon3/rc.png' usemap='#map' >
 <map name="map">
-	<area shape="rect" coords="14,12,36,33" id ="116" title="Power" onclick="pressMenuRemote('116');">	
-	<area shape="rect" coords="76,15,91,30" id ="113" title="mute" onclick="pressMenuRemote('113');">
+	<area shape="rect" coords="14,12,36,33" title="Power" onclick="pressMenuRemote('116');">	
+	<area shape="rect" coords="76,15,91,30" title="mute" onclick="pressMenuRemote('113');">
 		
-	<area shape="rect" coords="13,42,36,56" id ="138" title="help" onclick="pressMenuRemote('138');">	
-	<area shape="rect" coords="43,42,65,56" id ="102" title="home" onclick="pressMenuRemote('102');">	
-	<area shape="rect" coords="73,42,96,56" id ="107" title="end" onclick="pressMenuRemote('107');">
-	<area shape="rect" coords="13,62,36,76" id ="372" title="ZoomInOut" onclick="pressMenuRemote('372');">
-	<area shape="rect" coords="43,62,65,76" id ="59" title="F1" onclick="pressMenuRemote('59');">
-	<area shape="rect" coords="73,62,96,76" id ="376" title="Lan" onclick="pressMenuRemote('376');">
+	<area shape="rect" coords="13,42,36,56" title="help" onclick="pressMenuRemote('138');">	
+	<area shape="rect" coords="43,42,65,56" title="home" onclick="pressMenuRemote('102');">	
+	<area shape="rect" coords="73,42,96,56" title="end" onclick="pressMenuRemote('107');">
+	<area shape="rect" coords="13,62,36,76" title="ZoomInOut" onclick="pressMenuRemote('372');">
+	<area shape="rect" coords="43,62,65,76" title="F1" onclick="pressMenuRemote('59');">
+	<area shape="rect" coords="73,62,96,76" title="Lan" onclick="pressMenuRemote('376');">
 	
-	<area shape="rect" coords="13,84,34,99" id ="2" title="1" onclick="pressMenuRemote('2');">
-	<area shape="rect" coords="43,84,64,99" id ="3" title="2" onclick="pressMenuRemote('3');">	
-	<area shape="rect" coords="73,84,94,99" id ="4" title="3" onclick="pressMenuRemote('4');">
-	<area shape="rect" coords="13,108,34,123" id ="5" title="4" onclick="pressMenuRemote('5');">
-	<area shape="rect" coords="43,108,64,123" id ="6" title="5" onclick="pressMenuRemote('6');">
-	<area shape="rect" coords="73,108,94,123" id ="7" title="6" onclick="pressMenuRemote('7');">
-	<area shape="rect" coords="13,132,34,147" id ="8" title="7" onclick="pressMenuRemote('8');">
-	<area shape="rect" coords="43,132,64,147" id ="9" title="8" onclick="pressMenuRemote('9');">
-	<area shape="rect" coords="73,132,94,147" id ="10" title="9" onclick="pressMenuRemote('10');">
-	<area shape="rect" coords="13,154,34,171" id ="412" title="previous" onclick="pressMenuRemote('412');">
-	<area shape="rect" coords="43,154,64,171" id ="11" title="0" onclick="pressMenuRemote('11');">
-	<area shape="rect" coords="73,154,94,171" id ="407" title="next" onclick="pressMenuRemote('407');">
+	<area shape="rect" coords="13,84,34,99" title="1" onclick="pressMenuRemote('2');">
+	<area shape="rect" coords="43,84,64,99" title="2" onclick="pressMenuRemote('3');">	
+	<area shape="rect" coords="73,84,94,99" title="3" onclick="pressMenuRemote('4');">
+	<area shape="rect" coords="13,108,34,123" title="4" onclick="pressMenuRemote('5');">
+	<area shape="rect" coords="43,108,64,123" title="5" onclick="pressMenuRemote('6');">
+	<area shape="rect" coords="73,108,94,123" title="6" onclick="pressMenuRemote('7');">
+	<area shape="rect" coords="13,132,34,147" title="7" onclick="pressMenuRemote('8');">
+	<area shape="rect" coords="43,132,64,147" title="8" onclick="pressMenuRemote('9');">
+	<area shape="rect" coords="73,132,94,147" title="9" onclick="pressMenuRemote('10');">
+	<area shape="rect" coords="13,154,34,171" title="previous" onclick="pressMenuRemote('412');">
+	<area shape="rect" coords="43,154,64,171" title="0" onclick="pressMenuRemote('11');">
+	<area shape="rect" coords="73,154,94,171" title="next" onclick="pressMenuRemote('407');">
 
-	<area shape="rect" coords="9,182,35,208" id ="115" title="volume up" onclick="pressMenuRemote('115');">
-	<area shape="rect" coords="9,213,35,238" id ="114" title="volume down" onclick="pressMenuRemote('114');">
-	<area shape="rect" coords="74,182,98,208" id ="402" title="channelup" onclick="pressMenuRemote('402');">
-	<area shape="rect" coords="74,213,98,238" id ="403" title="channeldown" onclick="pressMenuRemote('403');">
-	<area shape="rect" coords="45,185,61,202" id ="365" title="EPGPressed" onclick="pressMenuRemote('365');">
-	<area shape="rect" coords="45,216,61,234" id ="358" title="info" onclick="pressMenuRemote('358');">
+	<area shape="rect" coords="9,182,35,208" title="volume up" onclick="pressMenuRemote('115');">
+	<area shape="rect" coords="9,213,35,238" title="volume down" onclick="pressMenuRemote('114');">
+	<area shape="rect" coords="74,182,98,208" title="channelup" onclick="pressMenuRemote('402');">
+	<area shape="rect" coords="74,213,98,238" title="channeldown" onclick="pressMenuRemote('403');">
+	<area shape="rect" coords="45,185,61,202" title="EPGPressed" onclick="pressMenuRemote('365');">
+	<area shape="rect" coords="45,216,61,234" title="info" onclick="pressMenuRemote('358');">
 
-	<area shape="rect" coords="9,249,27,261" id ="392" title="audio" onclick="pressMenuRemote('392');">
-	<area shape="rect" coords="32,249,51,261" id ="388" title="startTeletext" onclick="pressMenuRemote('388');">
-	<area shape="rect" coords="57,249,75,261" id ="370" title="subtitle" onclick="pressMenuRemote('370');">
-	<area shape="rect" coords="80,249,99,261" id ="362" title="openTimerList" onclick="pressMenuRemote('362');">
+	<area shape="rect" coords="9,249,27,261" title="audio" onclick="pressMenuRemote('392');">
+	<area shape="rect" coords="32,249,51,261" title="startTeletext" onclick="pressMenuRemote('388');">
+	<area shape="rect" coords="57,249,75,261" title="subtitle" onclick="pressMenuRemote('370');">
+	<area shape="rect" coords="80,249,99,261" title="openTimerList" onclick="pressMenuRemote('362');">
 
-	<area shape="rect" coords="8,270,23,286" id ="139" title="menu" onclick="pressMenuRemote('139');">
-	<area shape="rect" coords="85,270,99,286" id ="174" title="exit" onclick="pressMenuRemote('174');">
-	<area shape="rect" coords="8,341,23,358" id ="381" title="openSatellites" onclick="pressMenuRemote('381');">
-	<area shape="rect" coords="85,341,99,358" id ="406" title="prov" onclick="pressMenuRemote('406');">
+	<area shape="rect" coords="8,270,23,286" title="menu" onclick="pressMenuRemote('139');">
+	<area shape="rect" coords="85,270,99,286" title="exit" onclick="pressMenuRemote('174');">
+	<area shape="rect" coords="8,341,23,358" title="openSatellites" onclick="pressMenuRemote('381');">
+	<area shape="rect" coords="85,341,99,358" title="prov" onclick="pressMenuRemote('406');">
 
-	<area shape="rect" coords="38,279,68,296" id ="103" title="up" onclick="pressMenuRemote('103');">
-	<area shape="rect" coords="38,333,68,350" id ="108" title="down" onclick="pressMenuRemote('108');">
-	<area shape="rect" coords="18,299,36,329" id ="105" title="left" onclick="pressMenuRemote('105');">
-	<area shape="rect" coords="73,299,90,329" id ="106" title="right" onclick="pressMenuRemote('106');">
-	<area shape="rect" coords="41,301,67,318" id ="352" title="OK" onclick="pressMenuRemote('352');">
+	<area shape="rect" coords="38,279,68,296" title="up" onclick="pressMenuRemote('103');">
+	<area shape="rect" coords="38,333,68,350" title="down" onclick="pressMenuRemote('108');">
+	<area shape="rect" coords="18,299,36,329" title="left" onclick="pressMenuRemote('105');">
+	<area shape="rect" coords="73,299,90,329" title="right" onclick="pressMenuRemote('106');">
+	<area shape="rect" coords="41,301,67,318" title="OK" onclick="pressMenuRemote('352');">
 
-	<area shape="rect" coords="9,366,29,379" id ="398" title="red" onclick="pressMenuRemote('398');">
-	<area shape="rect" coords="32,366,51,379" id ="399" title="green" onclick="pressMenuRemote('399');">
-	<area shape="rect" coords="57,366,75,379" id ="400" title="yellow" onclick="pressMenuRemote('400');">
-	<area shape="rect" coords="80,366,99,379" id ="401" title="blue" onclick="pressMenuRemote('401');">
+	<area shape="rect" coords="9,366,29,379" title="red" onclick="pressMenuRemote('398');">
+	<area shape="rect" coords="32,366,51,379" title="green" onclick="pressMenuRemote('399');">
+	<area shape="rect" coords="57,366,75,379" title="yellow" onclick="pressMenuRemote('400');">
+	<area shape="rect" coords="80,366,99,379" title="blue" onclick="pressMenuRemote('401');">
 
-	<area shape="rect" coords="9,390,29,403" id ="393" title="showMovies" onclick="pressMenuRemote('393');">
-	<area shape="rect" coords="32,390,51,403" id ="395" title="showMediaPlayer" onclick="pressMenuRemote('395');">
-	<area shape="rect" coords="57,390,75,403" id ="394" title="ytube" onclick="pressMenuRemote('394');">
-	<area shape="rect" coords="80,390,99,403" id ="375" title="pip" onclick="pressMenuRemote('375');">
+	<area shape="rect" coords="9,390,29,403" title="showMovies" onclick="pressMenuRemote('393');">
+	<area shape="rect" coords="32,390,51,403" title="showMediaPlayer" onclick="pressMenuRemote('395');">
+	<area shape="rect" coords="57,390,75,403" title="ytube" onclick="pressMenuRemote('394');">
+	<area shape="rect" coords="80,390,99,403" title="pip" onclick="pressMenuRemote('375');">
 
-	<area shape="rect" coords="9,409,29,421" id ="168" title="rewind" onclick="pressMenuRemote('168');">
-	<area shape="rect" coords="32,409,51,421" id ="207" title="play" onclick="pressMenuRemote('207');">
-	<area shape="rect" coords="57,409,75,421" id ="119" title="pause" onclick="pressMenuRemote('119');">
-	<area shape="rect" coords="57,409,75,421" id ="164" title="timeshiftStart" onclick="pressMenuRemote('164');">
-	<area shape="rect" coords="80,409,99,421" id ="208" title="forward" onclick="pressMenuRemote('208');">
+	<area shape="rect" coords="9,409,29,421" title="rewind" onclick="pressMenuRemote('168');">
+	<area shape="rect" coords="32,409,51,421" title="play" onclick="pressMenuRemote('207');">
+	<area shape="rect" coords="57,409,75,421" title="pause" onclick="pressMenuRemote('119');">
+	<area shape="rect" coords="57,409,75,421" title="timeshiftStart" onclick="pressMenuRemote('164');">
+	<area shape="rect" coords="80,409,99,421" title="forward" onclick="pressMenuRemote('208');">
 
-	<area shape="rect" coords="9,428,29,441" id ="377" title="tv" onclick="pressMenuRemote('377');">
-	<area shape="rect" coords="32,428,51,441" id ="167" title="record" onclick="pressMenuRemote('167');">
-	<area shape="rect" coords="57,428,75,441" id ="128" title="timeshiftStop" onclick="pressMenuRemote('128');">	
-	<area shape="rect" coords="80,428,99,441" id ="385" title="radio" onclick="pressMenuRemote('385');">
+	<area shape="rect" coords="9,428,29,441" title="tv" onclick="pressMenuRemote('377');">
+	<area shape="rect" coords="32,428,51,441" title="record" onclick="pressMenuRemote('167');">
+	<area shape="rect" coords="57,428,75,441" title="timeshiftStop" onclick="pressMenuRemote('128');">	
+	<area shape="rect" coords="80,428,99,441" title="radio" onclick="pressMenuRemote('385');">
 </map>

--- a/BoxBranding/remotes/ixussone/remote.html
+++ b/BoxBranding/remotes/ixussone/remote.html
@@ -1,40 +1,40 @@
 <img border='0' src='/static/remotes/ixussone/rc.png' usemap='#map' >
 <map name="map">
 	<area shape="rect" coords="98,62,118,72" title="mute" onclick="pressMenuRemote('113');">
-	<area shape="rect" coords="105,28,15" id ="116" title="Power" onclick="pressMenuRemote('116');">
-	<area shape="rect" coords="33,53,15" id ="388" title="text" onclick="pressMenuRemote('388');">
-	<area shape="rect" coords="58,53,15" id ="370" title="subtitle" onclick="pressMenuRemote('370');">
-	<area shape="rect" coords="82,53,15" id ="102" title="home" onclick="pressMenuRemote('102');">
-	<area shape="rect" coords="105,53,15" id ="107" title="end" onclick="pressMenuRemote('107');">
+	<area shape="rect" coords="105,28,15" title="Power" onclick="pressMenuRemote('116');">
+	<area shape="rect" coords="33,53,15" title="text" onclick="pressMenuRemote('388');">
+	<area shape="rect" coords="58,53,15" title="subtitle" onclick="pressMenuRemote('370');">
+	<area shape="rect" coords="82,53,15" title="home" onclick="pressMenuRemote('102');">
+	<area shape="rect" coords="105,53,15" title="end" onclick="pressMenuRemote('107');">
 
-	<area shape="rect" coords="20,62,40,72" id ="2" title="1" onclick="pressMenuRemote('2');">
-	<area shape="rect" coords="46,62,66,72" id ="3" title="2" onclick="pressMenuRemote('3');">
-	<area shape="rect" coords="72,62,92,72" id ="4" title="3" onclick="pressMenuRemote('4');">
-	<area shape="rect" coords="20,78,40,88" id ="5" title="4" onclick="pressMenuRemote('5');">
-	<area shape="rect" coords="46,78,66,88" id ="6" title="5" onclick="pressMenuRemote('6');">
-	<area shape="rect" coords="72,78,92,88" id ="7" title="6" onclick="pressMenuRemote('7');">
-	<area shape="rect" coords="20,96,40,106" id ="8" title="7" onclick="pressMenuRemote('8');">
-	<area shape="rect" coords="46,96,66,106" id ="9" title="8" onclick="pressMenuRemote('9');">
-	<area shape="rect" coords="72,62,92,106" id ="10" title="9" onclick="pressMenuRemote('10');">
-	<area shape="rect" coords="46,112,66,125" id ="11" title="0" onclick="pressMenuRemote('11');">
+	<area shape="rect" coords="20,62,40,72" title="1" onclick="pressMenuRemote('2');">
+	<area shape="rect" coords="46,62,66,72" title="2" onclick="pressMenuRemote('3');">
+	<area shape="rect" coords="72,62,92,72" title="3" onclick="pressMenuRemote('4');">
+	<area shape="rect" coords="20,78,40,88" title="4" onclick="pressMenuRemote('5');">
+	<area shape="rect" coords="46,78,66,88" title="5" onclick="pressMenuRemote('6');">
+	<area shape="rect" coords="72,78,92,88" title="6" onclick="pressMenuRemote('7');">
+	<area shape="rect" coords="20,96,40,106" title="7" onclick="pressMenuRemote('8');">
+	<area shape="rect" coords="46,96,66,106" title="8" onclick="pressMenuRemote('9');">
+	<area shape="rect" coords="72,62,92,106" title="9" onclick="pressMenuRemote('10');">
+	<area shape="rect" coords="46,112,66,125" title="0" onclick="pressMenuRemote('11');">
 
 	<!-- Added Key -->
 	<area shape="rect" coords="96,95,118,107" title="Lan" onclick="pressMenuRemote(59);">
-	<area shape="circle" coords="104,214,18" id ="174" title="exit" onclick="pressMenuRemote('174');">
+	<area shape="circle" coords="104,214,18" title="exit" onclick="pressMenuRemote('174');">
 
-	<area shape="rect" coords="94,134,117,154" id ="402" title="channelup" onclick="pressMenuRemote('402');">
-	<area shape="rect" coords="94,174,117,194" id ="403" title="channeldown" onclick="pressMenuRemote('403');">
+	<area shape="rect" coords="94,134,117,154" title="channelup" onclick="pressMenuRemote('402');">
+	<area shape="rect" coords="94,174,117,194" title="channeldown" onclick="pressMenuRemote('403');">
 
-	<area shape="rect" coords="20,134,40,154" id ="115" title="volume up" onclick="pressMenuRemote('115');">
-	<area shape="rect" coords="20,174,40,194" id ="114" title="volume down" onclick="pressMenuRemote('114');">
+	<area shape="rect" coords="20,134,40,154" title="volume up" onclick="pressMenuRemote('115');">
+	<area shape="rect" coords="20,174,40,194" title="volume down" onclick="pressMenuRemote('114');">
 
-	<area shape="rect" coords="20,112,40,125" id ="412" title="previous" onclick="pressMenuRemote('412');">
-	<area shape="rect" coords="72,112,92,125" id ="407" title="next" onclick="pressMenuRemote('407');">
+	<area shape="rect" coords="20,112,40,125" title="previous" onclick="pressMenuRemote('412');">
+	<area shape="rect" coords="72,112,92,125" title="next" onclick="pressMenuRemote('407');">
 
-	<area shape="rect" coords="20,323,41,332" id ="398" title="red" onclick="pressMenuRemote('398');">
-	<area shape="rect" coords="45,323,66,332" id ="399" title="green" onclick="pressMenuRemote('399');">
-	<area shape="rect" coords="70,323,91,332" id ="400" title="yellow" onclick="pressMenuRemote('400');">
-	<area shape="rect" coords="95,323,116,332" id ="401" title="blue" onclick="pressMenuRemote('401');">
+	<area shape="rect" coords="20,323,41,332" title="red" onclick="pressMenuRemote('398');">
+	<area shape="rect" coords="45,323,66,332" title="green" onclick="pressMenuRemote('399');">
+	<area shape="rect" coords="70,323,91,332" title="yellow" onclick="pressMenuRemote('400');">
+	<area shape="rect" coords="95,323,116,332" title="blue" onclick="pressMenuRemote('401');">
 
 	<area shape="circle" coords="69,145,15" title="EPGPressed" onclick="pressMenuRemote(365);">
 	<area shape="circle" coords="33,280,20" title="openSatellites" onclick="pressMenuRemote(381);">
@@ -67,74 +67,74 @@
 	<!-- Rf modulator -->
 	<area shape="rect" coords="98,114,116,124" title="showRFmod" onclick="pressMenuRemote(63);">
 
-	<area shape="circle" coords="70,213,15" id ="103" title="up" onclick="pressMenuRemote('103');">
-	<area shape="circle" coords="70,283,15" id ="108" title="down" onclick="pressMenuRemote('108');">
-	<area shape="circle" coords="35,248,15" id ="105" title="left" onclick="pressMenuRemote('105');">
-	<area shape="circle" coords="105,248,15" id ="106" title="right" onclick="pressMenuRemote('106');">
+	<area shape="circle" coords="70,213,15" title="up" onclick="pressMenuRemote('103');">
+	<area shape="circle" coords="70,283,15" title="down" onclick="pressMenuRemote('108');">
+	<area shape="circle" coords="35,248,15" title="left" onclick="pressMenuRemote('105');">
+	<area shape="circle" coords="105,248,15" title="right" onclick="pressMenuRemote('106');">
 
-	<area shape="circle" coords="70,248,20" id ="352" title="OK" onclick="pressMenuRemote('352');">
-	<area shape="circle" coords="69,180,15" id ="392" title="audio" onclick="pressMenuRemote('392');">
+	<area shape="circle" coords="70,248,20" title="OK" onclick="pressMenuRemote('352');">
+	<area shape="circle" coords="69,180,15" title="audio" onclick="pressMenuRemote('392');">
 
-	<area shape="circle" coords="32,214,18" id ="139" title="menu" onclick="pressMenuRemote('139');">
-	<area shape="rect" coords="55,342,82,358" id ="167" title="record" onclick="pressMenuRemote('167');">
-	<area shape="rect" coords="20,342,46,357" id ="393" title="videoaltlast" onclick="pressMenuRemote('393');">
+	<area shape="circle" coords="32,214,18" title="menu" onclick="pressMenuRemote('139');">
+	<area shape="rect" coords="55,342,82,358" title="record" onclick="pressMenuRemote('167');">
+	<area shape="rect" coords="20,342,46,357" title="videoaltlast" onclick="pressMenuRemote('393');">
 
-	<area shape="rect" coords="98,78,118,88" id ="138" title="help" onclick="pressMenuRemote('138');">
+	<area shape="rect" coords="98,78,118,88" title="help" onclick="pressMenuRemote('138');">
 
-	<area shape="circle" coords="36,383,15" id ="168" title="rewind" onclick="pressMenuRemote('168');">
-	<area shape="circle" coords="59,383,15" id ="207" title="play" onclick="pressMenuRemote('207');">
-	<area shape="circle" coords="81,383,15" id ="119" title="pause" onclick="pressMenuRemote('119');">
-	<area shape="circle" coords="104,383,15" id ="208" title="forward" onclick="pressMenuRemote('208');">
-	<area shape="circle" coords="36,405,15" id ="377" title="tv" onclick="pressMenuRemote('377');">
+	<area shape="circle" coords="36,383,15" title="rewind" onclick="pressMenuRemote('168');">
+	<area shape="circle" coords="59,383,15" title="play" onclick="pressMenuRemote('207');">
+	<area shape="circle" coords="81,383,15" title="pause" onclick="pressMenuRemote('119');">
+	<area shape="circle" coords="104,383,15" title="forward" onclick="pressMenuRemote('208');">
+	<area shape="circle" coords="36,405,15" title="tv" onclick="pressMenuRemote('377');">
 
 
-	<area shape="circle" coords="81,405,15" id ="128" title="stop" onclick="pressMenuRemote('128');">
-	<area shape="circle" coords="104,405,15" id ="385" title="radio" onclick="pressMenuRemote('385');">
+	<area shape="circle" coords="81,405,15" title="stop" onclick="pressMenuRemote('128');">
+	<area shape="circle" coords="104,405,15" title="radio" onclick="pressMenuRemote('385');">
 </map>
 <!--
 	<area shape="circle" coords="33,28,15" title="mute" onclick="pressMenuRemote('113');">
-	<area shape="circle" coords="105,28,15" id ="116" title="Power" onclick="pressMenuRemote('116');">
-	<area shape="circle" coords="33,53,15" id ="388" title="text" onclick="pressMenuRemote('388');">
-	<area shape="circle" coords="58,53,15" id ="370" title="subtitle" onclick="pressMenuRemote('370');">
-	<area shape="circle" coords="82,53,15" id ="102" title="home" onclick="pressMenuRemote('102');">
-	<area shape="circle" coords="105,53,15" id ="107" title="end" onclick="pressMenuRemote('107');">
-	<area shape="circle" coords="38,79,15" id ="2" title="1" onclick="pressMenuRemote('2');">
-	<area shape="circle" coords="70,79,15" id ="3" title="2" onclick="pressMenuRemote('3');">
-	<area shape="circle" coords="102,79,15" id ="4" title="3" onclick="pressMenuRemote('4');">
-	<area shape="circle" coords="38,106,15" id ="5" title="4" onclick="pressMenuRemote('5');">
-	<area shape="circle" coords="70,106,15" id ="6" title="5" onclick="pressMenuRemote('6');">
-	<area shape="circle" coords="102,106,15" id ="7" title="6" onclick="pressMenuRemote('7');">
-	<area shape="circle" coords="38,133,15" id ="8" title="7" onclick="pressMenuRemote('8');">
-	<area shape="circle" coords="70,133,15" id ="9" title="8" onclick="pressMenuRemote('9');">
-	<area shape="circle" coords="102,133,15" id ="10" title="9" onclick="pressMenuRemote('10');">
-	<area shape="circle" coords="38,161,15" id ="412" title="previous" onclick="pressMenuRemote('412');">
-	<area shape="circle" coords="70,161,15" id ="11" title="0" onclick="pressMenuRemote('11');">
-	<area shape="circle" coords="102,161,15" id ="407" title="next" onclick="pressMenuRemote('407');">
-	<area shape="circle" coords="33,186,15" id ="398" title="red" onclick="pressMenuRemote('398');">
-	<area shape="circle" coords="58,186,15" id ="399" title="green" onclick="pressMenuRemote('399');">
-	<area shape="circle" coords="82,186,15" id ="400" title="yellow" onclick="pressMenuRemote('400');">
-	<area shape="circle" coords="105,186,15" id ="401" title="blue" onclick="pressMenuRemote('401');">
-	<area shape="circle" coords="70,213,15" id ="103" title="up" onclick="pressMenuRemote('103');">
-	<area shape="circle" coords="70,283,15" id ="108" title="down" onclick="pressMenuRemote('108');">
-	<area shape="circle" coords="35,248,15" id ="105" title="left" onclick="pressMenuRemote('105');">
-	<area shape="circle" coords="105,248,15" id ="106" title="right" onclick="pressMenuRemote('106');">
-	<area shape="circle" coords="70,248,20" id ="352" title="OK" onclick="pressMenuRemote('352');">
-	<area shape="circle" coords="40,307,15" id ="115" title="volume up" onclick="pressMenuRemote('115');">
-	<area shape="circle" coords="40,338,13" id ="114" title="volume down" onclick="pressMenuRemote('114');">
-	<area shape="circle" coords="70,310,15" id ="174" title="exit" onclick="pressMenuRemote('174');">
-	<area shape="circle" coords="70,334,15" id ="358" title="epg" onclick="pressMenuRemote('358');">
-	<area shape="circle" coords="99,307,15" id ="402" title="channelup" onclick="pressMenuRemote('402');">
-	<area shape="circle" coords="99,338,15" id ="403" title="channeldown" onclick="pressMenuRemote('403');">
-	<area shape="circle" coords="36,362,15" id ="139" title="menu" onclick="pressMenuRemote('139');">
-	<area shape="circle" coords="59,362,15" id ="393" title="videoaltlast" onclick="pressMenuRemote('393');">
-	<area shape="circle" coords="81,362,15" id ="392" title="audio" onclick="pressMenuRemote('392');">
-	<area shape="circle" coords="104,362,15" id ="138" title="help" onclick="pressMenuRemote('138');">
-	<area shape="circle" coords="36,383,15" id ="168" title="rewind" onclick="pressMenuRemote('168');">
-	<area shape="circle" coords="59,383,15" id ="207" title="play" onclick="pressMenuRemote('207');">
-	<area shape="circle" coords="81,383,15" id ="119" title="pause" onclick="pressMenuRemote('119');">
-	<area shape="circle" coords="104,383,15" id ="208" title="forward" onclick="pressMenuRemote('208');">
-	<area shape="circle" coords="36,405,15" id ="377" title="tv" onclick="pressMenuRemote('377');">
-	<area shape="circle" coords="59,405,15" id ="167" title="record" onclick="pressMenuRemote('167');">
-	<area shape="circle" coords="81,405,15" id ="128" title="stop" onclick="pressMenuRemote('128');">
-	<area shape="circle" coords="104,405,15" id ="385" title="radio" onclick="pressMenuRemote('385');">
+	<area shape="circle" coords="105,28,15" title="Power" onclick="pressMenuRemote('116');">
+	<area shape="circle" coords="33,53,15" title="text" onclick="pressMenuRemote('388');">
+	<area shape="circle" coords="58,53,15" title="subtitle" onclick="pressMenuRemote('370');">
+	<area shape="circle" coords="82,53,15" title="home" onclick="pressMenuRemote('102');">
+	<area shape="circle" coords="105,53,15" title="end" onclick="pressMenuRemote('107');">
+	<area shape="circle" coords="38,79,15" title="1" onclick="pressMenuRemote('2');">
+	<area shape="circle" coords="70,79,15" title="2" onclick="pressMenuRemote('3');">
+	<area shape="circle" coords="102,79,15" title="3" onclick="pressMenuRemote('4');">
+	<area shape="circle" coords="38,106,15" title="4" onclick="pressMenuRemote('5');">
+	<area shape="circle" coords="70,106,15" title="5" onclick="pressMenuRemote('6');">
+	<area shape="circle" coords="102,106,15" title="6" onclick="pressMenuRemote('7');">
+	<area shape="circle" coords="38,133,15" title="7" onclick="pressMenuRemote('8');">
+	<area shape="circle" coords="70,133,15" title="8" onclick="pressMenuRemote('9');">
+	<area shape="circle" coords="102,133,15" title="9" onclick="pressMenuRemote('10');">
+	<area shape="circle" coords="38,161,15" title="previous" onclick="pressMenuRemote('412');">
+	<area shape="circle" coords="70,161,15" title="0" onclick="pressMenuRemote('11');">
+	<area shape="circle" coords="102,161,15" title="next" onclick="pressMenuRemote('407');">
+	<area shape="circle" coords="33,186,15" title="red" onclick="pressMenuRemote('398');">
+	<area shape="circle" coords="58,186,15" title="green" onclick="pressMenuRemote('399');">
+	<area shape="circle" coords="82,186,15" title="yellow" onclick="pressMenuRemote('400');">
+	<area shape="circle" coords="105,186,15" title="blue" onclick="pressMenuRemote('401');">
+	<area shape="circle" coords="70,213,15" title="up" onclick="pressMenuRemote('103');">
+	<area shape="circle" coords="70,283,15" title="down" onclick="pressMenuRemote('108');">
+	<area shape="circle" coords="35,248,15" title="left" onclick="pressMenuRemote('105');">
+	<area shape="circle" coords="105,248,15" title="right" onclick="pressMenuRemote('106');">
+	<area shape="circle" coords="70,248,20" title="OK" onclick="pressMenuRemote('352');">
+	<area shape="circle" coords="40,307,15" title="volume up" onclick="pressMenuRemote('115');">
+	<area shape="circle" coords="40,338,13" title="volume down" onclick="pressMenuRemote('114');">
+	<area shape="circle" coords="70,310,15" title="exit" onclick="pressMenuRemote('174');">
+	<area shape="circle" coords="70,334,15" title="epg" onclick="pressMenuRemote('358');">
+	<area shape="circle" coords="99,307,15" title="channelup" onclick="pressMenuRemote('402');">
+	<area shape="circle" coords="99,338,15" title="channeldown" onclick="pressMenuRemote('403');">
+	<area shape="circle" coords="36,362,15" title="menu" onclick="pressMenuRemote('139');">
+	<area shape="circle" coords="59,362,15" title="videoaltlast" onclick="pressMenuRemote('393');">
+	<area shape="circle" coords="81,362,15" title="audio" onclick="pressMenuRemote('392');">
+	<area shape="circle" coords="104,362,15" title="help" onclick="pressMenuRemote('138');">
+	<area shape="circle" coords="36,383,15" title="rewind" onclick="pressMenuRemote('168');">
+	<area shape="circle" coords="59,383,15" title="play" onclick="pressMenuRemote('207');">
+	<area shape="circle" coords="81,383,15" title="pause" onclick="pressMenuRemote('119');">
+	<area shape="circle" coords="104,383,15" title="forward" onclick="pressMenuRemote('208');">
+	<area shape="circle" coords="36,405,15" title="tv" onclick="pressMenuRemote('377');">
+	<area shape="circle" coords="59,405,15" title="record" onclick="pressMenuRemote('167');">
+	<area shape="circle" coords="81,405,15" title="stop" onclick="pressMenuRemote('128');">
+	<area shape="circle" coords="104,405,15" title="radio" onclick="pressMenuRemote('385');">
 	-->

--- a/BoxBranding/remotes/ixusszero/remote.html
+++ b/BoxBranding/remotes/ixusszero/remote.html
@@ -1,40 +1,40 @@
 <img border='0' src='/static/remotes/ixusszero/rc.png' usemap='#map' >
 <map name="map">
 	<area shape="rect" coords="98,62,118,72" title="mute" onclick="pressMenuRemote('113');">
-	<area shape="rect" coords="105,28,15" id ="116" title="Power" onclick="pressMenuRemote('116');">
-	<area shape="rect" coords="33,53,15" id ="388" title="text" onclick="pressMenuRemote('388');">
-	<area shape="rect" coords="58,53,15" id ="370" title="subtitle" onclick="pressMenuRemote('370');">
-	<area shape="rect" coords="82,53,15" id ="102" title="home" onclick="pressMenuRemote('102');">
-	<area shape="rect" coords="105,53,15" id ="107" title="end" onclick="pressMenuRemote('107');">
+	<area shape="rect" coords="105,28,15" title="Power" onclick="pressMenuRemote('116');">
+	<area shape="rect" coords="33,53,15" title="text" onclick="pressMenuRemote('388');">
+	<area shape="rect" coords="58,53,15" title="subtitle" onclick="pressMenuRemote('370');">
+	<area shape="rect" coords="82,53,15" title="home" onclick="pressMenuRemote('102');">
+	<area shape="rect" coords="105,53,15" title="end" onclick="pressMenuRemote('107');">
 
-	<area shape="rect" coords="20,62,40,72" id ="2" title="1" onclick="pressMenuRemote('2');">
-	<area shape="rect" coords="46,62,66,72" id ="3" title="2" onclick="pressMenuRemote('3');">
-	<area shape="rect" coords="72,62,92,72" id ="4" title="3" onclick="pressMenuRemote('4');">
-	<area shape="rect" coords="20,78,40,88" id ="5" title="4" onclick="pressMenuRemote('5');">
-	<area shape="rect" coords="46,78,66,88" id ="6" title="5" onclick="pressMenuRemote('6');">
-	<area shape="rect" coords="72,78,92,88" id ="7" title="6" onclick="pressMenuRemote('7');">
-	<area shape="rect" coords="20,96,40,106" id ="8" title="7" onclick="pressMenuRemote('8');">
-	<area shape="rect" coords="46,96,66,106" id ="9" title="8" onclick="pressMenuRemote('9');">
-	<area shape="rect" coords="72,62,92,106" id ="10" title="9" onclick="pressMenuRemote('10');">
-	<area shape="rect" coords="46,112,66,125" id ="11" title="0" onclick="pressMenuRemote('11');">
+	<area shape="rect" coords="20,62,40,72" title="1" onclick="pressMenuRemote('2');">
+	<area shape="rect" coords="46,62,66,72" title="2" onclick="pressMenuRemote('3');">
+	<area shape="rect" coords="72,62,92,72" title="3" onclick="pressMenuRemote('4');">
+	<area shape="rect" coords="20,78,40,88" title="4" onclick="pressMenuRemote('5');">
+	<area shape="rect" coords="46,78,66,88" title="5" onclick="pressMenuRemote('6');">
+	<area shape="rect" coords="72,78,92,88" title="6" onclick="pressMenuRemote('7');">
+	<area shape="rect" coords="20,96,40,106" title="7" onclick="pressMenuRemote('8');">
+	<area shape="rect" coords="46,96,66,106" title="8" onclick="pressMenuRemote('9');">
+	<area shape="rect" coords="72,62,92,106" title="9" onclick="pressMenuRemote('10');">
+	<area shape="rect" coords="46,112,66,125" title="0" onclick="pressMenuRemote('11');">
 
 	<!-- Added Key -->
 	<area shape="rect" coords="96,95,118,107" title="Lan" onclick="pressMenuRemote(59);">
-	<area shape="circle" coords="104,214,18" id ="174" title="exit" onclick="pressMenuRemote('174');">
+	<area shape="circle" coords="104,214,18" title="exit" onclick="pressMenuRemote('174');">
 
-	<area shape="rect" coords="94,134,117,154" id ="402" title="channelup" onclick="pressMenuRemote('402');">
-	<area shape="rect" coords="94,174,117,194" id ="403" title="channeldown" onclick="pressMenuRemote('403');">
+	<area shape="rect" coords="94,134,117,154" title="channelup" onclick="pressMenuRemote('402');">
+	<area shape="rect" coords="94,174,117,194" title="channeldown" onclick="pressMenuRemote('403');">
 
-	<area shape="rect" coords="20,134,40,154" id ="115" title="volume up" onclick="pressMenuRemote('115');">
-	<area shape="rect" coords="20,174,40,194" id ="114" title="volume down" onclick="pressMenuRemote('114');">
+	<area shape="rect" coords="20,134,40,154" title="volume up" onclick="pressMenuRemote('115');">
+	<area shape="rect" coords="20,174,40,194" title="volume down" onclick="pressMenuRemote('114');">
 
-	<area shape="rect" coords="20,112,40,125" id ="412" title="previous" onclick="pressMenuRemote('412');">
-	<area shape="rect" coords="72,112,92,125" id ="407" title="next" onclick="pressMenuRemote('407');">
+	<area shape="rect" coords="20,112,40,125" title="previous" onclick="pressMenuRemote('412');">
+	<area shape="rect" coords="72,112,92,125" title="next" onclick="pressMenuRemote('407');">
 
-	<area shape="rect" coords="20,323,41,332" id ="398" title="red" onclick="pressMenuRemote('398');">
-	<area shape="rect" coords="45,323,66,332" id ="399" title="green" onclick="pressMenuRemote('399');">
-	<area shape="rect" coords="70,323,91,332" id ="400" title="yellow" onclick="pressMenuRemote('400');">
-	<area shape="rect" coords="95,323,116,332" id ="401" title="blue" onclick="pressMenuRemote('401');">
+	<area shape="rect" coords="20,323,41,332" title="red" onclick="pressMenuRemote('398');">
+	<area shape="rect" coords="45,323,66,332" title="green" onclick="pressMenuRemote('399');">
+	<area shape="rect" coords="70,323,91,332" title="yellow" onclick="pressMenuRemote('400');">
+	<area shape="rect" coords="95,323,116,332" title="blue" onclick="pressMenuRemote('401');">
 
 	<area shape="circle" coords="69,145,15" title="EPGPressed" onclick="pressMenuRemote(365);">
 	<area shape="circle" coords="33,280,20" title="openSatellites" onclick="pressMenuRemote(381);">
@@ -67,74 +67,74 @@
 	<!-- Rf modulator -->
 	<area shape="rect" coords="98,114,116,124" title="showRFmod" onclick="pressMenuRemote(63);">
 
-	<area shape="circle" coords="70,213,15" id ="103" title="up" onclick="pressMenuRemote('103');">
-	<area shape="circle" coords="70,283,15" id ="108" title="down" onclick="pressMenuRemote('108');">
-	<area shape="circle" coords="35,248,15" id ="105" title="left" onclick="pressMenuRemote('105');">
-	<area shape="circle" coords="105,248,15" id ="106" title="right" onclick="pressMenuRemote('106');">
+	<area shape="circle" coords="70,213,15" title="up" onclick="pressMenuRemote('103');">
+	<area shape="circle" coords="70,283,15" title="down" onclick="pressMenuRemote('108');">
+	<area shape="circle" coords="35,248,15" title="left" onclick="pressMenuRemote('105');">
+	<area shape="circle" coords="105,248,15" title="right" onclick="pressMenuRemote('106');">
 
-	<area shape="circle" coords="70,248,20" id ="352" title="OK" onclick="pressMenuRemote('352');">
-	<area shape="circle" coords="69,180,15" id ="392" title="audio" onclick="pressMenuRemote('392');">
+	<area shape="circle" coords="70,248,20" title="OK" onclick="pressMenuRemote('352');">
+	<area shape="circle" coords="69,180,15" title="audio" onclick="pressMenuRemote('392');">
 
-	<area shape="circle" coords="32,214,18" id ="139" title="menu" onclick="pressMenuRemote('139');">
-	<area shape="rect" coords="55,342,82,358" id ="167" title="record" onclick="pressMenuRemote('167');">
-	<area shape="rect" coords="20,342,46,357" id ="393" title="videoaltlast" onclick="pressMenuRemote('393');">
+	<area shape="circle" coords="32,214,18" title="menu" onclick="pressMenuRemote('139');">
+	<area shape="rect" coords="55,342,82,358" title="record" onclick="pressMenuRemote('167');">
+	<area shape="rect" coords="20,342,46,357" title="videoaltlast" onclick="pressMenuRemote('393');">
 
-	<area shape="rect" coords="98,78,118,88" id ="138" title="help" onclick="pressMenuRemote('138');">
+	<area shape="rect" coords="98,78,118,88" title="help" onclick="pressMenuRemote('138');">
 
-	<area shape="circle" coords="36,383,15" id ="168" title="rewind" onclick="pressMenuRemote('168');">
-	<area shape="circle" coords="59,383,15" id ="207" title="play" onclick="pressMenuRemote('207');">
-	<area shape="circle" coords="81,383,15" id ="119" title="pause" onclick="pressMenuRemote('119');">
-	<area shape="circle" coords="104,383,15" id ="208" title="forward" onclick="pressMenuRemote('208');">
-	<area shape="circle" coords="36,405,15" id ="377" title="tv" onclick="pressMenuRemote('377');">
+	<area shape="circle" coords="36,383,15" title="rewind" onclick="pressMenuRemote('168');">
+	<area shape="circle" coords="59,383,15" title="play" onclick="pressMenuRemote('207');">
+	<area shape="circle" coords="81,383,15" title="pause" onclick="pressMenuRemote('119');">
+	<area shape="circle" coords="104,383,15" title="forward" onclick="pressMenuRemote('208');">
+	<area shape="circle" coords="36,405,15" title="tv" onclick="pressMenuRemote('377');">
 
 
-	<area shape="circle" coords="81,405,15" id ="128" title="stop" onclick="pressMenuRemote('128');">
-	<area shape="circle" coords="104,405,15" id ="385" title="radio" onclick="pressMenuRemote('385');">
+	<area shape="circle" coords="81,405,15" title="stop" onclick="pressMenuRemote('128');">
+	<area shape="circle" coords="104,405,15" title="radio" onclick="pressMenuRemote('385');">
 </map>
 <!--
 	<area shape="circle" coords="33,28,15" title="mute" onclick="pressMenuRemote('113');">
-	<area shape="circle" coords="105,28,15" id ="116" title="Power" onclick="pressMenuRemote('116');">
-	<area shape="circle" coords="33,53,15" id ="388" title="text" onclick="pressMenuRemote('388');">
-	<area shape="circle" coords="58,53,15" id ="370" title="subtitle" onclick="pressMenuRemote('370');">
-	<area shape="circle" coords="82,53,15" id ="102" title="home" onclick="pressMenuRemote('102');">
-	<area shape="circle" coords="105,53,15" id ="107" title="end" onclick="pressMenuRemote('107');">
-	<area shape="circle" coords="38,79,15" id ="2" title="1" onclick="pressMenuRemote('2');">
-	<area shape="circle" coords="70,79,15" id ="3" title="2" onclick="pressMenuRemote('3');">
-	<area shape="circle" coords="102,79,15" id ="4" title="3" onclick="pressMenuRemote('4');">
-	<area shape="circle" coords="38,106,15" id ="5" title="4" onclick="pressMenuRemote('5');">
-	<area shape="circle" coords="70,106,15" id ="6" title="5" onclick="pressMenuRemote('6');">
-	<area shape="circle" coords="102,106,15" id ="7" title="6" onclick="pressMenuRemote('7');">
-	<area shape="circle" coords="38,133,15" id ="8" title="7" onclick="pressMenuRemote('8');">
-	<area shape="circle" coords="70,133,15" id ="9" title="8" onclick="pressMenuRemote('9');">
-	<area shape="circle" coords="102,133,15" id ="10" title="9" onclick="pressMenuRemote('10');">
-	<area shape="circle" coords="38,161,15" id ="412" title="previous" onclick="pressMenuRemote('412');">
-	<area shape="circle" coords="70,161,15" id ="11" title="0" onclick="pressMenuRemote('11');">
-	<area shape="circle" coords="102,161,15" id ="407" title="next" onclick="pressMenuRemote('407');">
-	<area shape="circle" coords="33,186,15" id ="398" title="red" onclick="pressMenuRemote('398');">
-	<area shape="circle" coords="58,186,15" id ="399" title="green" onclick="pressMenuRemote('399');">
-	<area shape="circle" coords="82,186,15" id ="400" title="yellow" onclick="pressMenuRemote('400');">
-	<area shape="circle" coords="105,186,15" id ="401" title="blue" onclick="pressMenuRemote('401');">
-	<area shape="circle" coords="70,213,15" id ="103" title="up" onclick="pressMenuRemote('103');">
-	<area shape="circle" coords="70,283,15" id ="108" title="down" onclick="pressMenuRemote('108');">
-	<area shape="circle" coords="35,248,15" id ="105" title="left" onclick="pressMenuRemote('105');">
-	<area shape="circle" coords="105,248,15" id ="106" title="right" onclick="pressMenuRemote('106');">
-	<area shape="circle" coords="70,248,20" id ="352" title="OK" onclick="pressMenuRemote('352');">
-	<area shape="circle" coords="40,307,15" id ="115" title="volume up" onclick="pressMenuRemote('115');">
-	<area shape="circle" coords="40,338,13" id ="114" title="volume down" onclick="pressMenuRemote('114');">
-	<area shape="circle" coords="70,310,15" id ="174" title="exit" onclick="pressMenuRemote('174');">
-	<area shape="circle" coords="70,334,15" id ="358" title="epg" onclick="pressMenuRemote('358');">
-	<area shape="circle" coords="99,307,15" id ="402" title="channelup" onclick="pressMenuRemote('402');">
-	<area shape="circle" coords="99,338,15" id ="403" title="channeldown" onclick="pressMenuRemote('403');">
-	<area shape="circle" coords="36,362,15" id ="139" title="menu" onclick="pressMenuRemote('139');">
-	<area shape="circle" coords="59,362,15" id ="393" title="videoaltlast" onclick="pressMenuRemote('393');">
-	<area shape="circle" coords="81,362,15" id ="392" title="audio" onclick="pressMenuRemote('392');">
-	<area shape="circle" coords="104,362,15" id ="138" title="help" onclick="pressMenuRemote('138');">
-	<area shape="circle" coords="36,383,15" id ="168" title="rewind" onclick="pressMenuRemote('168');">
-	<area shape="circle" coords="59,383,15" id ="207" title="play" onclick="pressMenuRemote('207');">
-	<area shape="circle" coords="81,383,15" id ="119" title="pause" onclick="pressMenuRemote('119');">
-	<area shape="circle" coords="104,383,15" id ="208" title="forward" onclick="pressMenuRemote('208');">
-	<area shape="circle" coords="36,405,15" id ="377" title="tv" onclick="pressMenuRemote('377');">
-	<area shape="circle" coords="59,405,15" id ="167" title="record" onclick="pressMenuRemote('167');">
-	<area shape="circle" coords="81,405,15" id ="128" title="stop" onclick="pressMenuRemote('128');">
-	<area shape="circle" coords="104,405,15" id ="385" title="radio" onclick="pressMenuRemote('385');">
+	<area shape="circle" coords="105,28,15" title="Power" onclick="pressMenuRemote('116');">
+	<area shape="circle" coords="33,53,15" title="text" onclick="pressMenuRemote('388');">
+	<area shape="circle" coords="58,53,15" title="subtitle" onclick="pressMenuRemote('370');">
+	<area shape="circle" coords="82,53,15" title="home" onclick="pressMenuRemote('102');">
+	<area shape="circle" coords="105,53,15" title="end" onclick="pressMenuRemote('107');">
+	<area shape="circle" coords="38,79,15" title="1" onclick="pressMenuRemote('2');">
+	<area shape="circle" coords="70,79,15" title="2" onclick="pressMenuRemote('3');">
+	<area shape="circle" coords="102,79,15" title="3" onclick="pressMenuRemote('4');">
+	<area shape="circle" coords="38,106,15" title="4" onclick="pressMenuRemote('5');">
+	<area shape="circle" coords="70,106,15" title="5" onclick="pressMenuRemote('6');">
+	<area shape="circle" coords="102,106,15" title="6" onclick="pressMenuRemote('7');">
+	<area shape="circle" coords="38,133,15" title="7" onclick="pressMenuRemote('8');">
+	<area shape="circle" coords="70,133,15" title="8" onclick="pressMenuRemote('9');">
+	<area shape="circle" coords="102,133,15" title="9" onclick="pressMenuRemote('10');">
+	<area shape="circle" coords="38,161,15" title="previous" onclick="pressMenuRemote('412');">
+	<area shape="circle" coords="70,161,15" title="0" onclick="pressMenuRemote('11');">
+	<area shape="circle" coords="102,161,15" title="next" onclick="pressMenuRemote('407');">
+	<area shape="circle" coords="33,186,15" title="red" onclick="pressMenuRemote('398');">
+	<area shape="circle" coords="58,186,15" title="green" onclick="pressMenuRemote('399');">
+	<area shape="circle" coords="82,186,15" title="yellow" onclick="pressMenuRemote('400');">
+	<area shape="circle" coords="105,186,15" title="blue" onclick="pressMenuRemote('401');">
+	<area shape="circle" coords="70,213,15" title="up" onclick="pressMenuRemote('103');">
+	<area shape="circle" coords="70,283,15" title="down" onclick="pressMenuRemote('108');">
+	<area shape="circle" coords="35,248,15" title="left" onclick="pressMenuRemote('105');">
+	<area shape="circle" coords="105,248,15" title="right" onclick="pressMenuRemote('106');">
+	<area shape="circle" coords="70,248,20" title="OK" onclick="pressMenuRemote('352');">
+	<area shape="circle" coords="40,307,15" title="volume up" onclick="pressMenuRemote('115');">
+	<area shape="circle" coords="40,338,13" title="volume down" onclick="pressMenuRemote('114');">
+	<area shape="circle" coords="70,310,15" title="exit" onclick="pressMenuRemote('174');">
+	<area shape="circle" coords="70,334,15" title="epg" onclick="pressMenuRemote('358');">
+	<area shape="circle" coords="99,307,15" title="channelup" onclick="pressMenuRemote('402');">
+	<area shape="circle" coords="99,338,15" title="channeldown" onclick="pressMenuRemote('403');">
+	<area shape="circle" coords="36,362,15" title="menu" onclick="pressMenuRemote('139');">
+	<area shape="circle" coords="59,362,15" title="videoaltlast" onclick="pressMenuRemote('393');">
+	<area shape="circle" coords="81,362,15" title="audio" onclick="pressMenuRemote('392');">
+	<area shape="circle" coords="104,362,15" title="help" onclick="pressMenuRemote('138');">
+	<area shape="circle" coords="36,383,15" title="rewind" onclick="pressMenuRemote('168');">
+	<area shape="circle" coords="59,383,15" title="play" onclick="pressMenuRemote('207');">
+	<area shape="circle" coords="81,383,15" title="pause" onclick="pressMenuRemote('119');">
+	<area shape="circle" coords="104,383,15" title="forward" onclick="pressMenuRemote('208');">
+	<area shape="circle" coords="36,405,15" title="tv" onclick="pressMenuRemote('377');">
+	<area shape="circle" coords="59,405,15" title="record" onclick="pressMenuRemote('167');">
+	<area shape="circle" coords="81,405,15" title="stop" onclick="pressMenuRemote('128');">
+	<area shape="circle" coords="104,405,15" title="radio" onclick="pressMenuRemote('385');">
 	-->

--- a/BoxBranding/remotes/mediabox/remote.html
+++ b/BoxBranding/remotes/mediabox/remote.html
@@ -1,62 +1,62 @@
 <img border='0' src='/static/remotes/mediabox/rc.png' usemap='#map' >
 <map name="map">
-	<area shape="rect" coords="24,44,51,58" id ="138" title="help" onclick="pressMenuRemote('138');">
-	<area shape="rect" coords="58,44,84,56" id ="172" title="home" onclick="pressMenuRemote('172');">
-	<area shape="rect" coords="90,44,117,56" id ="107" title="end" onclick="pressMenuRemote('107');">
-	<area shape="rect" coords="58,66,84,78" id ="370" title="subtitle" onclick="pressMenuRemote('370');">
+	<area shape="rect" coords="24,44,51,58" title="help" onclick="pressMenuRemote('138');">
+	<area shape="rect" coords="58,44,84,56" title="home" onclick="pressMenuRemote('172');">
+	<area shape="rect" coords="90,44,117,56" title="end" onclick="pressMenuRemote('107');">
+	<area shape="rect" coords="58,66,84,78" title="subtitle" onclick="pressMenuRemote('370');">
 	<area shape="rect" coords="24,65,51,78" title="startTeletext" onclick="pressMenuRemote(388);">
 	<area shape="rect" coords="90,66,117,78" title="ZoomInOut" onclick="pressMenuRemote(372);">
-	<area shape="rect" coords="24,86,51,100" id ="393" title="videoaltlast" onclick="pressMenuRemote('393');">
+	<area shape="rect" coords="24,86,51,100" title="videoaltlast" onclick="pressMenuRemote('393');">
 	<area shape="rect" coords="58,86,84,100" title="showMediaPlayer" onclick="pressMenuRemote('395');">
 	<area shape="rect" coords="90,86,117,100" title="openTimerList" onclick="pressMenuRemote(362);">
 
-	<area shape="rect" coords="24,110,50,130" id ="115" title="volume up" onclick="pressMenuRemote('115');">
-	<area shape="rect" coords="24,145,50,160" id ="114" title="volume down" onclick="pressMenuRemote('114');">
+	<area shape="rect" coords="24,110,50,130" title="volume up" onclick="pressMenuRemote('115');">
+	<area shape="rect" coords="24,145,50,160" title="volume down" onclick="pressMenuRemote('114');">
 
 	<area shape="rect" coords="58,112,82,130" title="EPGPressed" onclick="pressMenuRemote(365);">
-	<area shape="rect" coords="58,142,82,160" id ="392" title="audio" onclick="pressMenuRemote('392');">
+	<area shape="rect" coords="58,142,82,160" title="audio" onclick="pressMenuRemote('392');">
 
-	<area shape="rect" coords="90,110,118,130" id ="402" title="channelup" onclick="pressMenuRemote('402');">
-	<area shape="rect" coords="90,140,118,160" id ="403" title="channeldown" onclick="pressMenuRemote('403');">
+	<area shape="rect" coords="90,110,118,130" title="channelup" onclick="pressMenuRemote('402');">
+	<area shape="rect" coords="90,140,118,160" title="channeldown" onclick="pressMenuRemote('403');">
 
 
-	<area shape="circle" coords="32,181,16" id ="139" title="menu" onclick="pressMenuRemote('139');">
-	<area shape="circle" coords="108,181,16" id ="174" title="exit" onclick="pressMenuRemote('174');">
+	<area shape="circle" coords="32,181,16" title="menu" onclick="pressMenuRemote('139');">
+	<area shape="circle" coords="108,181,16" title="exit" onclick="pressMenuRemote('174');">
 
 	<area shape="circle" coords="32,245,16" title="openSatellites" onclick="pressMenuRemote(381);">
 
-	<area shape="circle" coords="70,187,16" id ="103" title="up" onclick="pressMenuRemote('103');">
-	<area shape="circle" coords="70,238,16" id ="108" title="down" onclick="pressMenuRemote('108');">
-	<area shape="circle" coords="46,212,16" id ="105" title="left" onclick="pressMenuRemote('105');">
-	<area shape="circle" coords="96,212,16" id ="106" title="right" onclick="pressMenuRemote('106');">
-	<area shape="circle" coords="72,213,20" id ="352" title="OK" onclick="pressMenuRemote('352');">
+	<area shape="circle" coords="70,187,16" title="up" onclick="pressMenuRemote('103');">
+	<area shape="circle" coords="70,238,16" title="down" onclick="pressMenuRemote('108');">
+	<area shape="circle" coords="46,212,16" title="left" onclick="pressMenuRemote('105');">
+	<area shape="circle" coords="96,212,16" title="right" onclick="pressMenuRemote('106');">
+	<area shape="circle" coords="72,213,20" title="OK" onclick="pressMenuRemote('352');">
 
 	<area shape="rect" coords="24,18,48,31" title="mute" onclick="pressMenuRemote('113');">
-	<area shape="rect" coords="96,15,116,34" id ="116" title="Power" onclick="pressMenuRemote('116');">
+	<area shape="rect" coords="96,15,116,34" title="Power" onclick="pressMenuRemote('116');">
 
 
-	<area shape="rect" coords="23,260,52,278" id ="2" title="1" onclick="pressMenuRemote('2');">
-	<area shape="rect" coords="58,260,83,278" id ="3" title="2" onclick="pressMenuRemote('3');">
-	<area shape="rect" coords="91,260,118,278" id ="4" title="3" onclick="pressMenuRemote('4');">
-	<area shape="rect" coords="23,287,52,307" id ="5" title="4" onclick="pressMenuRemote('5');">
-	<area shape="rect" coords="58,287,83,307" id ="6" title="5" onclick="pressMenuRemote('6');">
-	<area shape="rect" coords="91,287,118,307" id ="7" title="6" onclick="pressMenuRemote('7');">
-	<area shape="rect" coords="23,318,52,336" id ="8" title="7" onclick="pressMenuRemote('8');">
-	<area shape="rect" coords="58,318,83,336" id ="9" title="8" onclick="pressMenuRemote('9');">
-	<area shape="rect" coords="91,318,118,336" id ="10" title="9" onclick="pressMenuRemote('10');">
-	<area shape="rect" coords="58,346,83,363" id ="11" title="0" onclick="pressMenuRemote('11');">
+	<area shape="rect" coords="23,260,52,278" title="1" onclick="pressMenuRemote('2');">
+	<area shape="rect" coords="58,260,83,278" title="2" onclick="pressMenuRemote('3');">
+	<area shape="rect" coords="91,260,118,278" title="3" onclick="pressMenuRemote('4');">
+	<area shape="rect" coords="23,287,52,307" title="4" onclick="pressMenuRemote('5');">
+	<area shape="rect" coords="58,287,83,307" title="5" onclick="pressMenuRemote('6');">
+	<area shape="rect" coords="91,287,118,307" title="6" onclick="pressMenuRemote('7');">
+	<area shape="rect" coords="23,318,52,336" title="7" onclick="pressMenuRemote('8');">
+	<area shape="rect" coords="58,318,83,336" title="8" onclick="pressMenuRemote('9');">
+	<area shape="rect" coords="91,318,118,336" title="9" onclick="pressMenuRemote('10');">
+	<area shape="rect" coords="58,346,83,363" title="0" onclick="pressMenuRemote('11');">
 
-	<area shape="rect" coords="23,346,52,363" id ="412" title="previous" onclick="pressMenuRemote('412');">
-	<area shape="rect" coords="91,346,118,363" id ="407" title="next" onclick="pressMenuRemote('407');">
+	<area shape="rect" coords="23,346,52,363" title="previous" onclick="pressMenuRemote('412');">
+	<area shape="rect" coords="91,346,118,363" title="next" onclick="pressMenuRemote('407');">
 
-	<area shape="rect" coords="23,375,42,393" id ="398" title="red" onclick="pressMenuRemote('398');">
-	<area shape="rect" coords="50,375,69,393" id ="399" title="green" onclick="pressMenuRemote('399');">
-	<area shape="rect" coords="76,375,93,393" id ="400" title="yellow" onclick="pressMenuRemote('400');">
-	<area shape="rect" coords="100,375,119,393" id ="401" title="blue" onclick="pressMenuRemote('401');">
+	<area shape="rect" coords="23,375,42,393" title="red" onclick="pressMenuRemote('398');">
+	<area shape="rect" coords="50,375,69,393" title="green" onclick="pressMenuRemote('399');">
+	<area shape="rect" coords="76,375,93,393" title="yellow" onclick="pressMenuRemote('400');">
+	<area shape="rect" coords="100,375,119,393" title="blue" onclick="pressMenuRemote('401');">
 
 	<area shape="rect" coords="98,62,118,72" title="mute" onclick="pressMenuRemote('113');">
-	<area shape="rect" coords="96,15,116,34" id ="116" title="Power" onclick="pressMenuRemote('116');">
-	<area shape="rect" coords="24,65,50,78" id ="388" title="text" onclick="pressMenuRemote('388');">
+	<area shape="rect" coords="96,15,116,34" title="Power" onclick="pressMenuRemote('116');">
+	<area shape="rect" coords="24,65,50,78" title="text" onclick="pressMenuRemote('388');">
 
 	<area shape="circle" coords="33,280,20" title="openSatellites" onclick="pressMenuRemote(381);">
 
@@ -64,16 +64,16 @@
 	<area shape="rect" coords="76,401,93,416" title="timeshiftStart" onclick="pressMenuRemote(119);">
 	<area shape="rect" coords="76,424,93,440" title="timeshiftStop" onclick="pressMenuRemote(128);">
 
-	<area shape="circle" coords="108,240,16" id ="358" title="Info" onclick="pressMenuRemote('358');">
+	<area shape="circle" coords="108,240,16" title="Info" onclick="pressMenuRemote('358');">
 
 	<!-- Fastforward, rewind -->
-	<area shape="rect" coords="23,400,42,416" id ="168" title="rewind" onclick="pressMenuRemote('168');">
-	<area shape="rect" coords="50,400,69,416" id ="207" title="play" onclick="pressMenuRemote('207');">
-	<area shape="rect" coords="75,400,94,416" id ="119" title="pause" onclick="pressMenuRemote('119');">
-	<area shape="rect" coords="100,400,118,416" id ="208" title="forward" onclick="pressMenuRemote('208');">
+	<area shape="rect" coords="23,400,42,416" title="rewind" onclick="pressMenuRemote('168');">
+	<area shape="rect" coords="50,400,69,416" title="play" onclick="pressMenuRemote('207');">
+	<area shape="rect" coords="75,400,94,416" title="pause" onclick="pressMenuRemote('119');">
+	<area shape="rect" coords="100,400,118,416" title="forward" onclick="pressMenuRemote('208');">
 
 	<!-- Key Radio, and Tv -->
 	<area shape="rect" coords="100,424,118,440" title="radio" onclick="pressMenuRemote(385);">
 	<area shape="rect" coords="23,424,42,440" title="tv" onclick="pressMenuRemote(377);">
-	<area shape="rect" coords="50,424,69,440" id ="167" title="record" onclick="pressMenuRemote('167');">
+	<area shape="rect" coords="50,424,69,440" title="record" onclick="pressMenuRemote('167');">
 </map>

--- a/BoxBranding/remotes/megasat1/remote.html
+++ b/BoxBranding/remotes/megasat1/remote.html
@@ -1,40 +1,40 @@
 <img border='0' src='/static/remotes/megasat1/rc.png' usemap='#map' >
 <map name="map">
 	<area shape="rect" coords="14,19,39,33" title="mute" onclick="pressMenuRemote('113');">
-	<area shape="rect" coords="87,16,107,35" id ="116" title="Power" onclick="pressMenuRemote('116');">
-	<area shape="rect" coords="14,65,40,79" id ="388" title="text" onclick="pressMenuRemote('388');">
-	<area shape="rect" coords="47,66,73,79" id ="370" title="subtitle" onclick="pressMenuRemote('370');">
-	<area shape="rect" coords="47,44,74,59" id ="172" title="home" onclick="pressMenuRemote('172');">
-	<area shape="rect" coords="80,44,104,59" id ="107" title="end" onclick="pressMenuRemote('107');">
+	<area shape="rect" coords="87,16,107,35" title="Power" onclick="pressMenuRemote('116');">
+	<area shape="rect" coords="14,65,40,79" title="text" onclick="pressMenuRemote('388');">
+	<area shape="rect" coords="47,66,73,79" title="subtitle" onclick="pressMenuRemote('370');">
+	<area shape="rect" coords="47,44,74,59" title="home" onclick="pressMenuRemote('172');">
+	<area shape="rect" coords="80,44,104,59" title="end" onclick="pressMenuRemote('107');">
 
-	<area shape="rect" coords="13,258,40,279" id ="2" title="1" onclick="pressMenuRemote('2');">
-	<area shape="rect" coords="47,258,74,279" id ="3" title="2" onclick="pressMenuRemote('3');">
-	<area shape="rect" coords="81,258,109,279" id ="4" title="3" onclick="pressMenuRemote('4');">
-	<area shape="rect" coords="13,287,40,307" id ="5" title="4" onclick="pressMenuRemote('5');">
-	<area shape="rect" coords="47,287,74,307" id ="6" title="5" onclick="pressMenuRemote('6');">
-	<area shape="rect" coords="81,287,109,307" id ="7" title="6" onclick="pressMenuRemote('7');">
-	<area shape="rect" coords="13,315,40,337" id ="8" title="7" onclick="pressMenuRemote('8');">
-	<area shape="rect" coords="47,315,74,337" id ="9" title="8" onclick="pressMenuRemote('9');">
-	<area shape="rect" coords="81,315,109,337" id ="10" title="9" onclick="pressMenuRemote('10');">
-	<area shape="rect" coords="47,344,74,364" id ="11" title="0" onclick="pressMenuRemote('11');">
+	<area shape="rect" coords="13,258,40,279" title="1" onclick="pressMenuRemote('2');">
+	<area shape="rect" coords="47,258,74,279" title="2" onclick="pressMenuRemote('3');">
+	<area shape="rect" coords="81,258,109,279" title="3" onclick="pressMenuRemote('4');">
+	<area shape="rect" coords="13,287,40,307" title="4" onclick="pressMenuRemote('5');">
+	<area shape="rect" coords="47,287,74,307" title="5" onclick="pressMenuRemote('6');">
+	<area shape="rect" coords="81,287,109,307" title="6" onclick="pressMenuRemote('7');">
+	<area shape="rect" coords="13,315,40,337" title="7" onclick="pressMenuRemote('8');">
+	<area shape="rect" coords="47,315,74,337" title="8" onclick="pressMenuRemote('9');">
+	<area shape="rect" coords="81,315,109,337" title="9" onclick="pressMenuRemote('10');">
+	<area shape="rect" coords="47,344,74,364" title="0" onclick="pressMenuRemote('11');">
 
 	<!-- Added Key -->
 	<!--<area shape="rect" coords="96,95,118,107" title="Lan" onclick="pressMenuRemote(59);">-->
-	<area shape="circle" coords="98,179,10" id ="174" title="exit" onclick="pressMenuRemote('174');">
+	<area shape="circle" coords="98,179,10" title="exit" onclick="pressMenuRemote('174');">
 
-	<area shape="rect" coords="80,109,107,133" id ="402" title="channelup" onclick="pressMenuRemote('402');">
-	<area shape="rect" coords="80,137,107,162" id ="403" title="channeldown" onclick="pressMenuRemote('403');">
+	<area shape="rect" coords="80,109,107,133" title="channelup" onclick="pressMenuRemote('402');">
+	<area shape="rect" coords="80,137,107,162" title="channeldown" onclick="pressMenuRemote('403');">
 
-	<area shape="rect" coords="14,109,40,133" id ="115" title="volume up" onclick="pressMenuRemote('115');">
-	<area shape="rect" coords="14,137,40,162" id ="114" title="volume down" onclick="pressMenuRemote('114');">
+	<area shape="rect" coords="14,109,40,133" title="volume up" onclick="pressMenuRemote('115');">
+	<area shape="rect" coords="14,137,40,162" title="volume down" onclick="pressMenuRemote('114');">
 
-	<area shape="rect" coords="13,343,41,364" id ="412" title="previous" onclick="pressMenuRemote('412');">
-	<area shape="rect" coords="80,343,108,364" id ="407" title="next" onclick="pressMenuRemote('407');">
+	<area shape="rect" coords="13,343,41,364" title="previous" onclick="pressMenuRemote('412');">
+	<area shape="rect" coords="80,343,108,364" title="next" onclick="pressMenuRemote('407');">
 
-	<area shape="rect" coords="14,375,32,392" id ="398" title="red" onclick="pressMenuRemote('398');">
-	<area shape="rect" coords="38,375,57,392" id ="399" title="green" onclick="pressMenuRemote('399');">
-	<area shape="rect" coords="64,375,83,392" id ="400" title="yellow" onclick="pressMenuRemote('400');">
-	<area shape="rect" coords="89,375,108,392" id ="401" title="blue" onclick="pressMenuRemote('401');">
+	<area shape="rect" coords="14,375,32,392" title="red" onclick="pressMenuRemote('398');">
+	<area shape="rect" coords="38,375,57,392" title="green" onclick="pressMenuRemote('399');">
+	<area shape="rect" coords="64,375,83,392" title="yellow" onclick="pressMenuRemote('400');">
+	<area shape="rect" coords="89,375,108,392" title="blue" onclick="pressMenuRemote('401');">
 
 	<area shape="rect" coords="48,115,73,129" title="EPGPressed" onclick="pressMenuRemote(365);">
 	<area shape="circle" coords="22,244,10" title="openSatellites" onclick="pressMenuRemote(381);">
@@ -66,76 +66,76 @@
 
 	<!-- Rf modulator -->
 	<!--<area shape="rect" coords="98,114,116,124" title="showRFmod" onclick="pressMenuRemote(63);">-->
-	<area shape="circle" coords="99,244,10" id ="358" title="Info" onclick="pressMenuRemote('358');">
+	<area shape="circle" coords="99,244,10" title="Info" onclick="pressMenuRemote('358');">
 
-	<area shape="circle" coords="61,184,7" id ="103" title="up" onclick="pressMenuRemote('103');">
-	<area shape="circle" coords="61,238,7" id ="108" title="down" onclick="pressMenuRemote('108');">
-	<area shape="circle" coords="33,211,7" id ="105" title="left" onclick="pressMenuRemote('105');">
-	<area shape="circle" coords="86,211,7" id ="106" title="right" onclick="pressMenuRemote('106');">
+	<area shape="circle" coords="61,184,7" title="up" onclick="pressMenuRemote('103');">
+	<area shape="circle" coords="61,238,7" title="down" onclick="pressMenuRemote('108');">
+	<area shape="circle" coords="33,211,7" title="left" onclick="pressMenuRemote('105');">
+	<area shape="circle" coords="86,211,7" title="right" onclick="pressMenuRemote('106');">
 
-	<area shape="circle" coords="61,211,15" id ="352" title="OK" onclick="pressMenuRemote('352');">
-	<area shape="rect" coords="47,143,72,157" id ="392" title="audio" onclick="pressMenuRemote('392');">
+	<area shape="circle" coords="61,211,15" title="OK" onclick="pressMenuRemote('352');">
+	<area shape="rect" coords="47,143,72,157" title="audio" onclick="pressMenuRemote('392');">
 
-	<area shape="circle" coords="22,178,10" id ="139" title="menu" onclick="pressMenuRemote('139');">
-	<area shape="rect" coords="38,423,57,441" id ="167" title="record" onclick="pressMenuRemote('167');">
-	<area shape="rect" coords="13,86,40,100" id ="393" title="videoaltlast" onclick="pressMenuRemote('393');">
+	<area shape="circle" coords="22,178,10" title="menu" onclick="pressMenuRemote('139');">
+	<area shape="rect" coords="38,423,57,441" title="record" onclick="pressMenuRemote('167');">
+	<area shape="rect" coords="13,86,40,100" title="videoaltlast" onclick="pressMenuRemote('393');">
 
-	<area shape="rect" coords="13,44,40,59" id ="138" title="help" onclick="pressMenuRemote('138');">
+	<area shape="rect" coords="13,44,40,59" title="help" onclick="pressMenuRemote('138');">
 
-	<area shape="rect" coords="14,400,32,417" id ="168" title="rewind" onclick="pressMenuRemote('168');">
-	<area shape="rect" coords="38,400,58,417" id ="207" title="play" onclick="pressMenuRemote('207');">
-	<area shape="rect" coords="64,400,82,417" id ="119" title="pause" onclick="pressMenuRemote('119');">
-	<area shape="rect" coords="89,400,107,417" id ="208" title="forward" onclick="pressMenuRemote('208');">
-	<area shape="rect" coords="13,424,31,441" id ="377" title="tv" onclick="pressMenuRemote('377');">
+	<area shape="rect" coords="14,400,32,417" title="rewind" onclick="pressMenuRemote('168');">
+	<area shape="rect" coords="38,400,58,417" title="play" onclick="pressMenuRemote('207');">
+	<area shape="rect" coords="64,400,82,417" title="pause" onclick="pressMenuRemote('119');">
+	<area shape="rect" coords="89,400,107,417" title="forward" onclick="pressMenuRemote('208');">
+	<area shape="rect" coords="13,424,31,441" title="tv" onclick="pressMenuRemote('377');">
 
 
-	<area shape="rect" coords="63,424,82,440" id ="128" title="stop" onclick="pressMenuRemote('128');">
-	<area shape="circle" coords="90,424,107,440" id ="385" title="radio" onclick="pressMenuRemote('385');">
+	<area shape="rect" coords="63,424,82,440" title="stop" onclick="pressMenuRemote('128');">
+	<area shape="circle" coords="90,424,107,440" title="radio" onclick="pressMenuRemote('385');">
 </map>
 <!--
 	<area shape="circle" coords="33,28,15" title="mute" onclick="pressMenuRemote('113');">
-	<area shape="circle" coords="105,28,15" id ="116" title="Power" onclick="pressMenuRemote('116');">
-	<area shape="circle" coords="33,53,15" id ="388" title="text" onclick="pressMenuRemote('388');">
-	<area shape="circle" coords="58,53,15" id ="370" title="subtitle" onclick="pressMenuRemote('370');">
-	<area shape="circle" coords="82,53,15" id ="102" title="home" onclick="pressMenuRemote('102');">
-	<area shape="circle" coords="105,53,15" id ="107" title="end" onclick="pressMenuRemote('107');">
-	<area shape="circle" coords="38,79,15" id ="2" title="1" onclick="pressMenuRemote('2');">
-	<area shape="circle" coords="70,79,15" id ="3" title="2" onclick="pressMenuRemote('3');">
-	<area shape="circle" coords="102,79,15" id ="4" title="3" onclick="pressMenuRemote('4');">
-	<area shape="circle" coords="38,106,15" id ="5" title="4" onclick="pressMenuRemote('5');">
-	<area shape="circle" coords="70,106,15" id ="6" title="5" onclick="pressMenuRemote('6');">
-	<area shape="circle" coords="102,106,15" id ="7" title="6" onclick="pressMenuRemote('7');">
-	<area shape="circle" coords="38,133,15" id ="8" title="7" onclick="pressMenuRemote('8');">
-	<area shape="circle" coords="70,133,15" id ="9" title="8" onclick="pressMenuRemote('9');">
-	<area shape="circle" coords="102,133,15" id ="10" title="9" onclick="pressMenuRemote('10');">
-	<area shape="circle" coords="38,161,15" id ="412" title="previous" onclick="pressMenuRemote('412');">
-	<area shape="circle" coords="70,161,15" id ="11" title="0" onclick="pressMenuRemote('11');">
-	<area shape="circle" coords="102,161,15" id ="407" title="next" onclick="pressMenuRemote('407');">
-	<area shape="circle" coords="33,186,15" id ="398" title="red" onclick="pressMenuRemote('398');">
-	<area shape="circle" coords="58,186,15" id ="399" title="green" onclick="pressMenuRemote('399');">
-	<area shape="circle" coords="82,186,15" id ="400" title="yellow" onclick="pressMenuRemote('400');">
-	<area shape="circle" coords="105,186,15" id ="401" title="blue" onclick="pressMenuRemote('401');">
-	<area shape="circle" coords="70,213,15" id ="103" title="up" onclick="pressMenuRemote('103');">
-	<area shape="circle" coords="70,283,15" id ="108" title="down" onclick="pressMenuRemote('108');">
-	<area shape="circle" coords="35,248,15" id ="105" title="left" onclick="pressMenuRemote('105');">
-	<area shape="circle" coords="105,248,15" id ="106" title="right" onclick="pressMenuRemote('106');">
-	<area shape="circle" coords="70,248,20" id ="352" title="OK" onclick="pressMenuRemote('352');">
-	<area shape="circle" coords="40,307,15" id ="115" title="volume up" onclick="pressMenuRemote('115');">
-	<area shape="circle" coords="40,338,13" id ="114" title="volume down" onclick="pressMenuRemote('114');">
-	<area shape="circle" coords="70,310,15" id ="174" title="exit" onclick="pressMenuRemote('174');">
-	<area shape="circle" coords="70,334,15" id ="358" title="epg" onclick="pressMenuRemote('358');">
-	<area shape="circle" coords="99,307,15" id ="402" title="channelup" onclick="pressMenuRemote('402');">
-	<area shape="circle" coords="99,338,15" id ="403" title="channeldown" onclick="pressMenuRemote('403');">
-	<area shape="circle" coords="36,362,15" id ="139" title="menu" onclick="pressMenuRemote('139');">
-	<area shape="circle" coords="59,362,15" id ="393" title="videoaltlast" onclick="pressMenuRemote('393');">
-	<area shape="circle" coords="81,362,15" id ="392" title="audio" onclick="pressMenuRemote('392');">
-	<area shape="circle" coords="104,362,15" id ="138" title="help" onclick="pressMenuRemote('138');">
-	<area shape="circle" coords="36,383,15" id ="168" title="rewind" onclick="pressMenuRemote('168');">
-	<area shape="circle" coords="59,383,15" id ="207" title="play" onclick="pressMenuRemote('207');">
-	<area shape="circle" coords="81,383,15" id ="119" title="pause" onclick="pressMenuRemote('119');">
-	<area shape="circle" coords="104,383,15" id ="208" title="forward" onclick="pressMenuRemote('208');">
-	<area shape="circle" coords="36,405,15" id ="377" title="tv" onclick="pressMenuRemote('377');">
-	<area shape="circle" coords="59,405,15" id ="167" title="record" onclick="pressMenuRemote('167');">
-	<area shape="circle" coords="81,405,15" id ="128" title="stop" onclick="pressMenuRemote('128');">
-	<area shape="circle" coords="104,405,15" id ="385" title="radio" onclick="pressMenuRemote('385');">
+	<area shape="circle" coords="105,28,15" title="Power" onclick="pressMenuRemote('116');">
+	<area shape="circle" coords="33,53,15" title="text" onclick="pressMenuRemote('388');">
+	<area shape="circle" coords="58,53,15" title="subtitle" onclick="pressMenuRemote('370');">
+	<area shape="circle" coords="82,53,15" title="home" onclick="pressMenuRemote('102');">
+	<area shape="circle" coords="105,53,15" title="end" onclick="pressMenuRemote('107');">
+	<area shape="circle" coords="38,79,15" title="1" onclick="pressMenuRemote('2');">
+	<area shape="circle" coords="70,79,15" title="2" onclick="pressMenuRemote('3');">
+	<area shape="circle" coords="102,79,15" title="3" onclick="pressMenuRemote('4');">
+	<area shape="circle" coords="38,106,15" title="4" onclick="pressMenuRemote('5');">
+	<area shape="circle" coords="70,106,15" title="5" onclick="pressMenuRemote('6');">
+	<area shape="circle" coords="102,106,15" title="6" onclick="pressMenuRemote('7');">
+	<area shape="circle" coords="38,133,15" title="7" onclick="pressMenuRemote('8');">
+	<area shape="circle" coords="70,133,15" title="8" onclick="pressMenuRemote('9');">
+	<area shape="circle" coords="102,133,15" title="9" onclick="pressMenuRemote('10');">
+	<area shape="circle" coords="38,161,15" title="previous" onclick="pressMenuRemote('412');">
+	<area shape="circle" coords="70,161,15" title="0" onclick="pressMenuRemote('11');">
+	<area shape="circle" coords="102,161,15" title="next" onclick="pressMenuRemote('407');">
+	<area shape="circle" coords="33,186,15" title="red" onclick="pressMenuRemote('398');">
+	<area shape="circle" coords="58,186,15" title="green" onclick="pressMenuRemote('399');">
+	<area shape="circle" coords="82,186,15" title="yellow" onclick="pressMenuRemote('400');">
+	<area shape="circle" coords="105,186,15" title="blue" onclick="pressMenuRemote('401');">
+	<area shape="circle" coords="70,213,15" title="up" onclick="pressMenuRemote('103');">
+	<area shape="circle" coords="70,283,15" title="down" onclick="pressMenuRemote('108');">
+	<area shape="circle" coords="35,248,15" title="left" onclick="pressMenuRemote('105');">
+	<area shape="circle" coords="105,248,15" title="right" onclick="pressMenuRemote('106');">
+	<area shape="circle" coords="70,248,20" title="OK" onclick="pressMenuRemote('352');">
+	<area shape="circle" coords="40,307,15" title="volume up" onclick="pressMenuRemote('115');">
+	<area shape="circle" coords="40,338,13" title="volume down" onclick="pressMenuRemote('114');">
+	<area shape="circle" coords="70,310,15" title="exit" onclick="pressMenuRemote('174');">
+	<area shape="circle" coords="70,334,15" title="epg" onclick="pressMenuRemote('358');">
+	<area shape="circle" coords="99,307,15" title="channelup" onclick="pressMenuRemote('402');">
+	<area shape="circle" coords="99,338,15" title="channeldown" onclick="pressMenuRemote('403');">
+	<area shape="circle" coords="36,362,15" title="menu" onclick="pressMenuRemote('139');">
+	<area shape="circle" coords="59,362,15" title="videoaltlast" onclick="pressMenuRemote('393');">
+	<area shape="circle" coords="81,362,15" title="audio" onclick="pressMenuRemote('392');">
+	<area shape="circle" coords="104,362,15" title="help" onclick="pressMenuRemote('138');">
+	<area shape="circle" coords="36,383,15" title="rewind" onclick="pressMenuRemote('168');">
+	<area shape="circle" coords="59,383,15" title="play" onclick="pressMenuRemote('207');">
+	<area shape="circle" coords="81,383,15" title="pause" onclick="pressMenuRemote('119');">
+	<area shape="circle" coords="104,383,15" title="forward" onclick="pressMenuRemote('208');">
+	<area shape="circle" coords="36,405,15" title="tv" onclick="pressMenuRemote('377');">
+	<area shape="circle" coords="59,405,15" title="record" onclick="pressMenuRemote('167');">
+	<area shape="circle" coords="81,405,15" title="stop" onclick="pressMenuRemote('128');">
+	<area shape="circle" coords="104,405,15" title="radio" onclick="pressMenuRemote('385');">
 	-->

--- a/BoxBranding/remotes/megasat2/remote.html
+++ b/BoxBranding/remotes/megasat2/remote.html
@@ -1,41 +1,41 @@
 <img border='0' src='/static/remotes/megasat2/rc.png' usemap='#map' >
 <map name="map">
 	<area shape="rect" coords="75,21,91,37" title="mute" onclick="pressMenuRemote('113');">
-	<area shape="rect" coords="16,20,36,39" id ="116" title="Power" onclick="pressMenuRemote('116');">
-	<area shape="rect" coords="33,248,52,259" id ="388" title="text" onclick="pressMenuRemote('388');">
-	<area shape="rect" coords="56,248,75,259" id ="370" title="subtitle" onclick="pressMenuRemote('370');">
-	<area shape="rect" coords="43,48,64,61" id ="172" title="home" onclick="pressMenuRemote('172');">
-	<area shape="rect" coords="71,48,93,60" id ="107" title="end" onclick="pressMenuRemote('107');">
+	<area shape="rect" coords="16,20,36,39" title="Power" onclick="pressMenuRemote('116');">
+	<area shape="rect" coords="33,248,52,259" title="text" onclick="pressMenuRemote('388');">
+	<area shape="rect" coords="56,248,75,259" title="subtitle" onclick="pressMenuRemote('370');">
+	<area shape="rect" coords="43,48,64,61" title="home" onclick="pressMenuRemote('172');">
+	<area shape="rect" coords="71,48,93,60" title="end" onclick="pressMenuRemote('107');">
 
-	<area shape="rect" coords="15,87,36,102" id ="2" title="1" onclick="pressMenuRemote('2');">
-	<area shape="rect" coords="44,87,65,102" id ="3" title="2" onclick="pressMenuRemote('3');">
-	<area shape="rect" coords="73,87,93,102" id ="4" title="3" onclick="pressMenuRemote('4');">
-	<area shape="rect" coords="15,109,36,125" id ="5" title="4" onclick="pressMenuRemote('5');">
-	<area shape="rect" coords="44,109,65,125" id ="6" title="5" onclick="pressMenuRemote('6');">
-	<area shape="rect" coords="73,109,93,125" id ="7" title="6" onclick="pressMenuRemote('7');">
-	<area shape="rect" coords="15,133,36,149" id ="8" title="7" onclick="pressMenuRemote('8');">
-	<area shape="rect" coords="44,133,65,149" id ="9" title="8" onclick="pressMenuRemote('9');">
-	<area shape="rect" coords="73,133,93,149" id ="10" title="9" onclick="pressMenuRemote('10');">
-	<area shape="rect" coords="44,157,65,171" id ="11" title="0" onclick="pressMenuRemote('11');">
+	<area shape="rect" coords="15,87,36,102" title="1" onclick="pressMenuRemote('2');">
+	<area shape="rect" coords="44,87,65,102" title="2" onclick="pressMenuRemote('3');">
+	<area shape="rect" coords="73,87,93,102" title="3" onclick="pressMenuRemote('4');">
+	<area shape="rect" coords="15,109,36,125" title="4" onclick="pressMenuRemote('5');">
+	<area shape="rect" coords="44,109,65,125" title="5" onclick="pressMenuRemote('6');">
+	<area shape="rect" coords="73,109,93,125" title="6" onclick="pressMenuRemote('7');">
+	<area shape="rect" coords="15,133,36,149" title="7" onclick="pressMenuRemote('8');">
+	<area shape="rect" coords="44,133,65,149" title="8" onclick="pressMenuRemote('9');">
+	<area shape="rect" coords="73,133,93,149" title="9" onclick="pressMenuRemote('10');">
+	<area shape="rect" coords="44,157,65,171" title="0" onclick="pressMenuRemote('11');">
 
 	<!-- Added Key -->
 	<area shape="rect" coords="72,68,93,80" title="Lan" onclick="pressMenuRemote(59);">
-	<area shape="circle" coords="91,275,8" id ="174" title="exit" onclick="pressMenuRemote('174');">
+	<area shape="circle" coords="91,275,8" title="exit" onclick="pressMenuRemote('174');">
 
-	<area shape="rect" coords="73,183,96,205" id ="402" title="channelup" onclick="pressMenuRemote('402');">
-	<area shape="rect" coords="73,213,96,234" id ="403" title="channeldown" onclick="pressMenuRemote('403');">
+	<area shape="rect" coords="73,183,96,205" title="channelup" onclick="pressMenuRemote('402');">
+	<area shape="rect" coords="73,213,96,234" title="channeldown" onclick="pressMenuRemote('403');">
 
-	<area shape="rect" coords="13,183,35,204" id ="115" title="volume up" onclick="pressMenuRemote('115');">
-	<area shape="rect" coords="13,214,35,235" id ="114" title="volume down" onclick="pressMenuRemote('114');">
+	<area shape="rect" coords="13,183,35,204" title="volume up" onclick="pressMenuRemote('115');">
+	<area shape="rect" coords="13,214,35,235" title="volume down" onclick="pressMenuRemote('114');">
 
-	<area shape="rect" coords="13,155,37,171" id ="412" title="previous" onclick="pressMenuRemote('412');">
-	<area shape="rect" coords="71,156,95,170" id ="407" title="next" onclick="pressMenuRemote('407');">
-	<area shape="circle" coords="53,224,9" id ="358" title="Info" onclick="pressMenuRemote('358');">
+	<area shape="rect" coords="13,155,37,171" title="previous" onclick="pressMenuRemote('412');">
+	<area shape="rect" coords="71,156,95,170" title="next" onclick="pressMenuRemote('407');">
+	<area shape="circle" coords="53,224,9" title="Info" onclick="pressMenuRemote('358');">
 
-	<area shape="rect" coords="11,361,28,371" id ="398" title="red" onclick="pressMenuRemote('398');">
-	<area shape="rect" coords="33,361,51,371" id ="399" title="green" onclick="pressMenuRemote('399');">
-	<area shape="rect" coords="56,361,74,371" id ="400" title="yellow" onclick="pressMenuRemote('400');">
-	<area shape="rect" coords="79,361,98,371" id ="401" title="blue" onclick="pressMenuRemote('401');">
+	<area shape="rect" coords="11,361,28,371" title="red" onclick="pressMenuRemote('398');">
+	<area shape="rect" coords="33,361,51,371" title="green" onclick="pressMenuRemote('399');">
+	<area shape="rect" coords="56,361,74,371" title="yellow" onclick="pressMenuRemote('400');">
+	<area shape="rect" coords="79,361,98,371" title="blue" onclick="pressMenuRemote('401');">
 
 	<area shape="circle" coords="54,194,8" title="EPGPressed" onclick="pressMenuRemote(365);">
 	<area shape="circle" coords="16,344,8" title="openSatellites" onclick="pressMenuRemote(381);">
@@ -47,9 +47,9 @@
 	<area shape="rect" coords="33,421,52,432" title="instantRecord" onclick="pressMenuRemote(167);">
 	<area shape="rect" coords="56,421,75,432" title="timeshiftStop" onclick="pressMenuRemote(128);">
 	
-	<area shape="rect" coords="55,383,76,395" id ="150" title="ytube" onclick="pressMenuRemote('150');">
-	<area shape="rect" coords="79,384,98,395" id ="375" title="pip" onclick="pressMenuRemote('375');">
-	<area shape="rect" coords="82,336,100,353" id ="406" title="prov" onclick="pressMenuRemote('406');">
+	<area shape="rect" coords="55,383,76,395" title="ytube" onclick="pressMenuRemote('150');">
+	<area shape="rect" coords="79,384,98,395" title="pip" onclick="pressMenuRemote('375');">
+	<area shape="rect" coords="82,336,100,353" title="prov" onclick="pressMenuRemote('406');">
 
 	<!-- Fastforward , rewind -->
 	<area shape="rect" coords="78,401,98,413" title="seekFwd" onclick="pressMenuRemote(208);">
@@ -71,74 +71,74 @@
 	<!-- Rf modulator -->
 	<area shape="rect" coords="43,67,66,81" title="showRFmod" onclick="pressMenuRemote(63);">
 
-	<area shape="circle" coords="54,282,8" id ="103" title="up" onclick="pressMenuRemote('103');">
-	<area shape="circle" coords="54,336,8" id ="108" title="down" onclick="pressMenuRemote('108');">
-	<area shape="circle" coords="26,309,8" id ="105" title="left" onclick="pressMenuRemote('105');">
-	<area shape="circle" coords="82,309,8" id ="106" title="right" onclick="pressMenuRemote('106');">
+	<area shape="circle" coords="54,282,8" title="up" onclick="pressMenuRemote('103');">
+	<area shape="circle" coords="54,336,8" title="down" onclick="pressMenuRemote('108');">
+	<area shape="circle" coords="26,309,8" title="left" onclick="pressMenuRemote('105');">
+	<area shape="circle" coords="82,309,8" title="right" onclick="pressMenuRemote('106');">
 
-	<area shape="circle" coords="54,309,12" id ="352" title="OK" onclick="pressMenuRemote('352');">
-	<area shape="circle" coords="19,252,8" id ="392" title="audio" onclick="pressMenuRemote('392');">
+	<area shape="circle" coords="54,309,12" title="OK" onclick="pressMenuRemote('352');">
+	<area shape="circle" coords="19,252,8" title="audio" onclick="pressMenuRemote('392');">
 
-	<area shape="circle" coords="17,275,8" id ="139" title="menu" onclick="pressMenuRemote('139');">
-	<area shape="rect" coords="33,421,51,432" id ="167" title="record" onclick="pressMenuRemote('167');">
-	<area shape="rect" coords="10,385,28,394" id ="393" title="videoaltlast" onclick="pressMenuRemote('393');">
+	<area shape="circle" coords="17,275,8" title="menu" onclick="pressMenuRemote('139');">
+	<area shape="rect" coords="33,421,51,432" title="record" onclick="pressMenuRemote('167');">
+	<area shape="rect" coords="10,385,28,394" title="videoaltlast" onclick="pressMenuRemote('393');">
 
-	<area shape="rect" coords="15,48,36,60" id ="138" title="help" onclick="pressMenuRemote('138');">
+	<area shape="rect" coords="15,48,36,60" title="help" onclick="pressMenuRemote('138');">
 
-	<area shape="rect" coords="11,403,28,413" id ="168" title="rewind" onclick="pressMenuRemote('168');">
-	<area shape="rect" coords="33,403,52,413" id ="207" title="play" onclick="pressMenuRemote('207');">
-	<area shape="rect" coords="57,403,74,413" id ="119" title="pause" onclick="pressMenuRemote('119');">
-	<area shape="rect" coords="79,403,98,413" id ="208" title="forward" onclick="pressMenuRemote('208');">
-	<area shape="rect" coords="10,421,28,431" id ="377" title="tv" onclick="pressMenuRemote('377');">
+	<area shape="rect" coords="11,403,28,413" title="rewind" onclick="pressMenuRemote('168');">
+	<area shape="rect" coords="33,403,52,413" title="play" onclick="pressMenuRemote('207');">
+	<area shape="rect" coords="57,403,74,413" title="pause" onclick="pressMenuRemote('119');">
+	<area shape="rect" coords="79,403,98,413" title="forward" onclick="pressMenuRemote('208');">
+	<area shape="rect" coords="10,421,28,431" title="tv" onclick="pressMenuRemote('377');">
 
 
-	<area shape="rect" coords="56,421,75,431" id ="128" title="stop" onclick="pressMenuRemote('128');">
-	<area shape="rect" coords="79,421,97,431" id ="385" title="radio" onclick="pressMenuRemote('385');">
+	<area shape="rect" coords="56,421,75,431" title="stop" onclick="pressMenuRemote('128');">
+	<area shape="rect" coords="79,421,97,431" title="radio" onclick="pressMenuRemote('385');">
 </map>
 <!--
 	<area shape="circle" coords="33,28,15" title="mute" onclick="pressMenuRemote('113');">
-	<area shape="circle" coords="105,28,15" id ="116" title="Power" onclick="pressMenuRemote('116');">
-	<area shape="circle" coords="33,53,15" id ="388" title="text" onclick="pressMenuRemote('388');">
-	<area shape="circle" coords="58,53,15" id ="370" title="subtitle" onclick="pressMenuRemote('370');">
-	<area shape="circle" coords="82,53,15" id ="102" title="home" onclick="pressMenuRemote('102');">
-	<area shape="circle" coords="105,53,15" id ="107" title="end" onclick="pressMenuRemote('107');">
-	<area shape="circle" coords="38,79,15" id ="2" title="1" onclick="pressMenuRemote('2');">
-	<area shape="circle" coords="70,79,15" id ="3" title="2" onclick="pressMenuRemote('3');">
-	<area shape="circle" coords="102,79,15" id ="4" title="3" onclick="pressMenuRemote('4');">
-	<area shape="circle" coords="38,106,15" id ="5" title="4" onclick="pressMenuRemote('5');">
-	<area shape="circle" coords="70,106,15" id ="6" title="5" onclick="pressMenuRemote('6');">
-	<area shape="circle" coords="102,106,15" id ="7" title="6" onclick="pressMenuRemote('7');">
-	<area shape="circle" coords="38,133,15" id ="8" title="7" onclick="pressMenuRemote('8');">
-	<area shape="circle" coords="70,133,15" id ="9" title="8" onclick="pressMenuRemote('9');">
-	<area shape="circle" coords="102,133,15" id ="10" title="9" onclick="pressMenuRemote('10');">
-	<area shape="circle" coords="38,161,15" id ="412" title="previous" onclick="pressMenuRemote('412');">
-	<area shape="circle" coords="70,161,15" id ="11" title="0" onclick="pressMenuRemote('11');">
-	<area shape="circle" coords="102,161,15" id ="407" title="next" onclick="pressMenuRemote('407');">
-	<area shape="circle" coords="33,186,15" id ="398" title="red" onclick="pressMenuRemote('398');">
-	<area shape="circle" coords="58,186,15" id ="399" title="green" onclick="pressMenuRemote('399');">
-	<area shape="circle" coords="82,186,15" id ="400" title="yellow" onclick="pressMenuRemote('400');">
-	<area shape="circle" coords="105,186,15" id ="401" title="blue" onclick="pressMenuRemote('401');">
-	<area shape="circle" coords="70,213,15" id ="103" title="up" onclick="pressMenuRemote('103');">
-	<area shape="circle" coords="70,283,15" id ="108" title="down" onclick="pressMenuRemote('108');">
-	<area shape="circle" coords="35,248,15" id ="105" title="left" onclick="pressMenuRemote('105');">
-	<area shape="circle" coords="105,248,15" id ="106" title="right" onclick="pressMenuRemote('106');">
-	<area shape="circle" coords="70,248,20" id ="352" title="OK" onclick="pressMenuRemote('352');">
-	<area shape="circle" coords="40,307,15" id ="115" title="volume up" onclick="pressMenuRemote('115');">
-	<area shape="circle" coords="40,338,13" id ="114" title="volume down" onclick="pressMenuRemote('114');">
-	<area shape="circle" coords="70,310,15" id ="174" title="exit" onclick="pressMenuRemote('174');">
-	<area shape="circle" coords="70,334,15" id ="358" title="epg" onclick="pressMenuRemote('358');">
-	<area shape="circle" coords="99,307,15" id ="402" title="channelup" onclick="pressMenuRemote('402');">
-	<area shape="circle" coords="99,338,15" id ="403" title="channeldown" onclick="pressMenuRemote('403');">
-	<area shape="circle" coords="36,362,15" id ="139" title="menu" onclick="pressMenuRemote('139');">
-	<area shape="circle" coords="59,362,15" id ="393" title="videoaltlast" onclick="pressMenuRemote('393');">
-	<area shape="circle" coords="81,362,15" id ="392" title="audio" onclick="pressMenuRemote('392');">
-	<area shape="circle" coords="104,362,15" id ="138" title="help" onclick="pressMenuRemote('138');">
-	<area shape="circle" coords="36,383,15" id ="168" title="rewind" onclick="pressMenuRemote('168');">
-	<area shape="circle" coords="59,383,15" id ="207" title="play" onclick="pressMenuRemote('207');">
-	<area shape="circle" coords="81,383,15" id ="119" title="pause" onclick="pressMenuRemote('119');">
-	<area shape="circle" coords="104,383,15" id ="208" title="forward" onclick="pressMenuRemote('208');">
-	<area shape="circle" coords="36,405,15" id ="377" title="tv" onclick="pressMenuRemote('377');">
-	<area shape="circle" coords="59,405,15" id ="167" title="record" onclick="pressMenuRemote('167');">
-	<area shape="circle" coords="81,405,15" id ="128" title="stop" onclick="pressMenuRemote('128');">
-	<area shape="circle" coords="104,405,15" id ="385" title="radio" onclick="pressMenuRemote('385');">
+	<area shape="circle" coords="105,28,15" title="Power" onclick="pressMenuRemote('116');">
+	<area shape="circle" coords="33,53,15" title="text" onclick="pressMenuRemote('388');">
+	<area shape="circle" coords="58,53,15" title="subtitle" onclick="pressMenuRemote('370');">
+	<area shape="circle" coords="82,53,15" title="home" onclick="pressMenuRemote('102');">
+	<area shape="circle" coords="105,53,15" title="end" onclick="pressMenuRemote('107');">
+	<area shape="circle" coords="38,79,15" title="1" onclick="pressMenuRemote('2');">
+	<area shape="circle" coords="70,79,15" title="2" onclick="pressMenuRemote('3');">
+	<area shape="circle" coords="102,79,15" title="3" onclick="pressMenuRemote('4');">
+	<area shape="circle" coords="38,106,15" title="4" onclick="pressMenuRemote('5');">
+	<area shape="circle" coords="70,106,15" title="5" onclick="pressMenuRemote('6');">
+	<area shape="circle" coords="102,106,15" title="6" onclick="pressMenuRemote('7');">
+	<area shape="circle" coords="38,133,15" title="7" onclick="pressMenuRemote('8');">
+	<area shape="circle" coords="70,133,15" title="8" onclick="pressMenuRemote('9');">
+	<area shape="circle" coords="102,133,15" title="9" onclick="pressMenuRemote('10');">
+	<area shape="circle" coords="38,161,15" title="previous" onclick="pressMenuRemote('412');">
+	<area shape="circle" coords="70,161,15" title="0" onclick="pressMenuRemote('11');">
+	<area shape="circle" coords="102,161,15" title="next" onclick="pressMenuRemote('407');">
+	<area shape="circle" coords="33,186,15" title="red" onclick="pressMenuRemote('398');">
+	<area shape="circle" coords="58,186,15" title="green" onclick="pressMenuRemote('399');">
+	<area shape="circle" coords="82,186,15" title="yellow" onclick="pressMenuRemote('400');">
+	<area shape="circle" coords="105,186,15" title="blue" onclick="pressMenuRemote('401');">
+	<area shape="circle" coords="70,213,15" title="up" onclick="pressMenuRemote('103');">
+	<area shape="circle" coords="70,283,15" title="down" onclick="pressMenuRemote('108');">
+	<area shape="circle" coords="35,248,15" title="left" onclick="pressMenuRemote('105');">
+	<area shape="circle" coords="105,248,15" title="right" onclick="pressMenuRemote('106');">
+	<area shape="circle" coords="70,248,20" title="OK" onclick="pressMenuRemote('352');">
+	<area shape="circle" coords="40,307,15" title="volume up" onclick="pressMenuRemote('115');">
+	<area shape="circle" coords="40,338,13" title="volume down" onclick="pressMenuRemote('114');">
+	<area shape="circle" coords="70,310,15" title="exit" onclick="pressMenuRemote('174');">
+	<area shape="circle" coords="70,334,15" title="epg" onclick="pressMenuRemote('358');">
+	<area shape="circle" coords="99,307,15" title="channelup" onclick="pressMenuRemote('402');">
+	<area shape="circle" coords="99,338,15" title="channeldown" onclick="pressMenuRemote('403');">
+	<area shape="circle" coords="36,362,15" title="menu" onclick="pressMenuRemote('139');">
+	<area shape="circle" coords="59,362,15" title="videoaltlast" onclick="pressMenuRemote('393');">
+	<area shape="circle" coords="81,362,15" title="audio" onclick="pressMenuRemote('392');">
+	<area shape="circle" coords="104,362,15" title="help" onclick="pressMenuRemote('138');">
+	<area shape="circle" coords="36,383,15" title="rewind" onclick="pressMenuRemote('168');">
+	<area shape="circle" coords="59,383,15" title="play" onclick="pressMenuRemote('207');">
+	<area shape="circle" coords="81,383,15" title="pause" onclick="pressMenuRemote('119');">
+	<area shape="circle" coords="104,383,15" title="forward" onclick="pressMenuRemote('208');">
+	<area shape="circle" coords="36,405,15" title="tv" onclick="pressMenuRemote('377');">
+	<area shape="circle" coords="59,405,15" title="record" onclick="pressMenuRemote('167');">
+	<area shape="circle" coords="81,405,15" title="stop" onclick="pressMenuRemote('128');">
+	<area shape="circle" coords="104,405,15" title="radio" onclick="pressMenuRemote('385');">
 	-->

--- a/BoxBranding/remotes/optimuss1/remote.html
+++ b/BoxBranding/remotes/optimuss1/remote.html
@@ -1,78 +1,78 @@
 <img border='0' src='/static/remotes/optimuss1/rc.png' usemap='#map' >
 <map name="map">
-	<area shape="rect" coords="24,44,51,58" id ="138" title="help" onclick="pressMenuRemote('138');">
-	<area shape="rect" coords="58,44,84,56" id ="172" title="home" onclick="pressMenuRemote('172');">
-	<area shape="rect" coords="90,44,117,56" id ="107" title="end" onclick="pressMenuRemote('107');">
-	<area shape="rect" coords="58,66,84,78" id ="370" title="subtitle" onclick="pressMenuRemote('370');">
+	<area shape="rect" coords="24,44,51,58" title="help" onclick="pressMenuRemote('138');">
+	<area shape="rect" coords="58,44,84,56" title="home" onclick="pressMenuRemote('172');">
+	<area shape="rect" coords="90,44,117,56" title="end" onclick="pressMenuRemote('107');">
+	<area shape="rect" coords="58,66,84,78" title="subtitle" onclick="pressMenuRemote('370');">
 	<area shape="rect" coords="24,65,51,78" title="startTeletext" onclick="pressMenuRemote(388);">
 	<area shape="rect" coords="90,66,117,78" title="ZoomInOut" onclick="pressMenuRemote(372);">
-	<area shape="rect" coords="24,86,51,100" id ="393" title="videoaltlast" onclick="pressMenuRemote('393');">
+	<area shape="rect" coords="24,86,51,100" title="videoaltlast" onclick="pressMenuRemote('393');">
 	<area shape="rect" coords="58,86,84,100" title="showMediaPlayer" onclick="pressMenuRemote('395');">
 	<area shape="rect" coords="90,86,117,100" title="openTimerList" onclick="pressMenuRemote(362);">
 
-	<area shape="rect" coords="24,110,50,130" id ="115" title="volume up" onclick="pressMenuRemote('115');">
-	<area shape="rect" coords="24,145,50,160" id ="114" title="volume down" onclick="pressMenuRemote('114');">
+	<area shape="rect" coords="24,110,50,130" title="volume up" onclick="pressMenuRemote('115');">
+	<area shape="rect" coords="24,145,50,160" title="volume down" onclick="pressMenuRemote('114');">
 
 	<area shape="rect" coords="58,112,82,130" title="EPGPressed" onclick="pressMenuRemote(365);">
-	<area shape="rect" coords="58,142,82,160" id ="392" title="audio" onclick="pressMenuRemote('392');">
+	<area shape="rect" coords="58,142,82,160" title="audio" onclick="pressMenuRemote('392');">
 
-	<area shape="rect" coords="90,110,118,130" id ="402" title="channelup" onclick="pressMenuRemote('402');">
-	<area shape="rect" coords="90,140,118,160" id ="403" title="channeldown" onclick="pressMenuRemote('403');">
+	<area shape="rect" coords="90,110,118,130" title="channelup" onclick="pressMenuRemote('402');">
+	<area shape="rect" coords="90,140,118,160" title="channeldown" onclick="pressMenuRemote('403');">
 
 
-	<area shape="circle" coords="32,181,16" id ="139" title="menu" onclick="pressMenuRemote('139');">
-	<area shape="circle" coords="108,181,16" id ="174" title="exit" onclick="pressMenuRemote('174');">
+	<area shape="circle" coords="32,181,16" title="menu" onclick="pressMenuRemote('139');">
+	<area shape="circle" coords="108,181,16" title="exit" onclick="pressMenuRemote('174');">
 
 	<area shape="circle" coords="32,245,16" title="openSatellites" onclick="pressMenuRemote(381);">
 
-	<area shape="circle" coords="70,187,16" id ="103" title="up" onclick="pressMenuRemote('103');">
-	<area shape="circle" coords="70,238,16" id ="108" title="down" onclick="pressMenuRemote('108');">
-	<area shape="circle" coords="46,212,16" id ="105" title="left" onclick="pressMenuRemote('105');">
-	<area shape="circle" coords="96,212,16" id ="106" title="right" onclick="pressMenuRemote('106');">
-	<area shape="circle" coords="72,213,20" id ="352" title="OK" onclick="pressMenuRemote('352');">
+	<area shape="circle" coords="70,187,16" title="up" onclick="pressMenuRemote('103');">
+	<area shape="circle" coords="70,238,16" title="down" onclick="pressMenuRemote('108');">
+	<area shape="circle" coords="46,212,16" title="left" onclick="pressMenuRemote('105');">
+	<area shape="circle" coords="96,212,16" title="right" onclick="pressMenuRemote('106');">
+	<area shape="circle" coords="72,213,20" title="OK" onclick="pressMenuRemote('352');">
 
 	<area shape="rect" coords="24,18,48,31" title="mute" onclick="pressMenuRemote('113');">
-	<area shape="rect" coords="96,15,116,34" id ="116" title="Power" onclick="pressMenuRemote('116');">
+	<area shape="rect" coords="96,15,116,34" title="Power" onclick="pressMenuRemote('116');">
 
 
-	<area shape="rect" coords="23,260,52,278" id ="2" title="1" onclick="pressMenuRemote('2');">
-	<area shape="rect" coords="58,260,83,278" id ="3" title="2" onclick="pressMenuRemote('3');">
-	<area shape="rect" coords="91,260,118,278" id ="4" title="3" onclick="pressMenuRemote('4');">
-	<area shape="rect" coords="23,287,52,307" id ="5" title="4" onclick="pressMenuRemote('5');">
-	<area shape="rect" coords="58,287,83,307" id ="6" title="5" onclick="pressMenuRemote('6');">
-	<area shape="rect" coords="91,287,118,307" id ="7" title="6" onclick="pressMenuRemote('7');">
-	<area shape="rect" coords="23,318,52,336" id ="8" title="7" onclick="pressMenuRemote('8');">
-	<area shape="rect" coords="58,318,83,336" id ="9" title="8" onclick="pressMenuRemote('9');">
-	<area shape="rect" coords="91,318,118,336" id ="10" title="9" onclick="pressMenuRemote('10');">
-	<area shape="rect" coords="58,346,83,363" id ="11" title="0" onclick="pressMenuRemote('11');">
+	<area shape="rect" coords="23,260,52,278" title="1" onclick="pressMenuRemote('2');">
+	<area shape="rect" coords="58,260,83,278" title="2" onclick="pressMenuRemote('3');">
+	<area shape="rect" coords="91,260,118,278" title="3" onclick="pressMenuRemote('4');">
+	<area shape="rect" coords="23,287,52,307" title="4" onclick="pressMenuRemote('5');">
+	<area shape="rect" coords="58,287,83,307" title="5" onclick="pressMenuRemote('6');">
+	<area shape="rect" coords="91,287,118,307" title="6" onclick="pressMenuRemote('7');">
+	<area shape="rect" coords="23,318,52,336" title="7" onclick="pressMenuRemote('8');">
+	<area shape="rect" coords="58,318,83,336" title="8" onclick="pressMenuRemote('9');">
+	<area shape="rect" coords="91,318,118,336" title="9" onclick="pressMenuRemote('10');">
+	<area shape="rect" coords="58,346,83,363" title="0" onclick="pressMenuRemote('11');">
 
-	<area shape="rect" coords="23,346,52,363" id ="412" title="previous" onclick="pressMenuRemote('412');">
-	<area shape="rect" coords="91,346,118,363" id ="407" title="next" onclick="pressMenuRemote('407');">
+	<area shape="rect" coords="23,346,52,363" title="previous" onclick="pressMenuRemote('412');">
+	<area shape="rect" coords="91,346,118,363" title="next" onclick="pressMenuRemote('407');">
 
-	<area shape="rect" coords="23,375,42,393" id ="398" title="red" onclick="pressMenuRemote('398');">
-	<area shape="rect" coords="50,375,69,393" id ="399" title="green" onclick="pressMenuRemote('399');">
-	<area shape="rect" coords="76,375,93,393" id ="400" title="yellow" onclick="pressMenuRemote('400');">
-	<area shape="rect" coords="100,375,119,393" id ="401" title="blue" onclick="pressMenuRemote('401');">
+	<area shape="rect" coords="23,375,42,393" title="red" onclick="pressMenuRemote('398');">
+	<area shape="rect" coords="50,375,69,393" title="green" onclick="pressMenuRemote('399');">
+	<area shape="rect" coords="76,375,93,393" title="yellow" onclick="pressMenuRemote('400');">
+	<area shape="rect" coords="100,375,119,393" title="blue" onclick="pressMenuRemote('401');">
 
 	<area shape="rect" coords="98,62,118,72" title="mute" onclick="pressMenuRemote('113');">
-	<area shape="rect" coords="96,15,116,34" id ="116" title="Power" onclick="pressMenuRemote('116');">
-	<area shape="rect" coords="24,65,50,78" id ="388" title="text" onclick="pressMenuRemote('388');">
+	<area shape="rect" coords="96,15,116,34" title="Power" onclick="pressMenuRemote('116');">
+	<area shape="rect" coords="24,65,50,78" title="text" onclick="pressMenuRemote('388');">
 
 	<area shape="circle" coords="33,280,20" title="openSatellites" onclick="pressMenuRemote(381);">
 
 	<area shape="rect" coords="20,342,48,355" title="showMovies" onclick="pressMenuRemote(393);">
 	<area shape="rect" coords="76,401,93,416" title="timeshiftStart" onclick="pressMenuRemote(119);">
 	<area shape="rect" coords="76,424,93,440" title="timeshiftStop" onclick="pressMenuRemote(128);">
-	<area shape="circle" coords="110,244,12" id ="358" title="Info" onclick="pressMenuRemote('358');">
+	<area shape="circle" coords="110,244,12" title="Info" onclick="pressMenuRemote('358');">
 
 	<!-- Fastforward, rewind -->
-	<area shape="rect" coords="23,400,42,416" id ="168" title="rewind" onclick="pressMenuRemote('168');">
-	<area shape="rect" coords="50,400,69,416" id ="207" title="play" onclick="pressMenuRemote('207');">
-	<area shape="rect" coords="75,400,94,416" id ="119" title="pause" onclick="pressMenuRemote('119');">
-	<area shape="rect" coords="100,400,118,416" id ="208" title="forward" onclick="pressMenuRemote('208');">
+	<area shape="rect" coords="23,400,42,416" title="rewind" onclick="pressMenuRemote('168');">
+	<area shape="rect" coords="50,400,69,416" title="play" onclick="pressMenuRemote('207');">
+	<area shape="rect" coords="75,400,94,416" title="pause" onclick="pressMenuRemote('119');">
+	<area shape="rect" coords="100,400,118,416" title="forward" onclick="pressMenuRemote('208');">
 
 	<!-- Key Radio, and Tv -->
 	<area shape="rect" coords="100,424,118,440" title="radio" onclick="pressMenuRemote(385);">
 	<area shape="rect" coords="23,424,42,440" title="tv" onclick="pressMenuRemote(377);">
-	<area shape="rect" coords="50,424,69,440" id ="167" title="record" onclick="pressMenuRemote('167');">
+	<area shape="rect" coords="50,424,69,440" title="record" onclick="pressMenuRemote('167');">
 </map>

--- a/BoxBranding/remotes/optimuss2/remote.html
+++ b/BoxBranding/remotes/optimuss2/remote.html
@@ -1,62 +1,62 @@
 <img border='0' src='/static/remotes/optimuss2/rc.png' usemap='#map' >
 <map name="map">
-	<area shape="rect" coords="20,70,37,79" id ="138" title="help" onclick="pressMenuRemote('138');">
-	<area shape="rect" coords="46,69,63,79" id ="172" title="home" onclick="pressMenuRemote('172');">
-	<area shape="rect" coords="71,69,88,79" id ="107" title="end" onclick="pressMenuRemote('107');">
-	<area shape="rect" coords="58,350,72,358" id ="370" title="subtitle" onclick="pressMenuRemote('370');">
+	<area shape="rect" coords="20,70,37,79" title="help" onclick="pressMenuRemote('138');">
+	<area shape="rect" coords="46,69,63,79" title="home" onclick="pressMenuRemote('172');">
+	<area shape="rect" coords="71,69,88,79" title="end" onclick="pressMenuRemote('107');">
+	<area shape="rect" coords="58,350,72,358" title="subtitle" onclick="pressMenuRemote('370');">
 	<area shape="rect" coords="37,349,51,357" title="startTeletext" onclick="pressMenuRemote(388);">
 	<area shape="rect" coords="21,86,37,96" title="ZoomInOut" onclick="pressMenuRemote(372);">
-	<area shape="rect" coords="16,370,31,379" id ="393" title="videoaltlast" onclick="pressMenuRemote('393');">
+	<area shape="rect" coords="16,370,31,379" title="videoaltlast" onclick="pressMenuRemote('393');">
 	<area shape="rect" coords="37,370,51,379" title="showMediaPlayer" onclick="pressMenuRemote('395');">
 	<area shape="rect" coords="78,349,93,358" title="openTimerList" onclick="pressMenuRemote(362);">
-	<area shape="circle" coords="55,224,10" id ="358" title="Info" onclick="pressMenuRemote('358');">
+	<area shape="circle" coords="55,224,10" title="Info" onclick="pressMenuRemote('358');">
 
-	<area shape="circle" coords="27,197,9" id ="115" title="volume up" onclick="pressMenuRemote('115');">
-	<area shape="circle" coords="27,224,9" id ="114" title="volume down" onclick="pressMenuRemote('114');">
+	<area shape="circle" coords="27,197,9" title="volume up" onclick="pressMenuRemote('115');">
+	<area shape="circle" coords="27,224,9" title="volume down" onclick="pressMenuRemote('114');">
 
 	<area shape="circel" coords="54,197,7" title="EPGPressed" onclick="pressMenuRemote(365);">
-	<area shape="rect" coords="16,349,30,357" id ="392" title="audio" onclick="pressMenuRemote('392');">
+	<area shape="rect" coords="16,349,30,357" title="audio" onclick="pressMenuRemote('392');">
 
-	<area shape="rect" coords="82,197,9" id ="402" title="channelup" onclick="pressMenuRemote('402');">
-	<area shape="rect" coords="82,224,9" id ="403" title="channeldown" onclick="pressMenuRemote('403');">
+	<area shape="rect" coords="82,197,9" title="channelup" onclick="pressMenuRemote('402');">
+	<area shape="rect" coords="82,224,9" title="channeldown" onclick="pressMenuRemote('403');">
 
-	<area shape="circle" coords="21,270,7" id ="139" title="menu" onclick="pressMenuRemote('139');">
-	<area shape="circle" coords="88,270,7" id ="174" title="exit" onclick="pressMenuRemote('174');">
+	<area shape="circle" coords="21,270,7" title="menu" onclick="pressMenuRemote('139');">
+	<area shape="circle" coords="88,270,7" title="exit" onclick="pressMenuRemote('174');">
 
 	<area shape="circle" coords="21,334,7" title="openSatellites" onclick="pressMenuRemote(381);">
 
-	<area shape="rect" coords="41,272,67,284" id ="103" title="up" onclick="pressMenuRemote('103');">
-	<area shape="rect" coords="41,318,67,328" id ="108" title="down" onclick="pressMenuRemote('108');">
-	<area shape="rect" coords="25,286,38,315" id ="105" title="left" onclick="pressMenuRemote('105');">
-	<area shape="rect" coords="71,286,82,315" id ="106" title="right" onclick="pressMenuRemote('106');">
-	<area shape="circle" coords="54,302,9" id ="352" title="OK" onclick="pressMenuRemote('352');">
+	<area shape="rect" coords="41,272,67,284" title="up" onclick="pressMenuRemote('103');">
+	<area shape="rect" coords="41,318,67,328" title="down" onclick="pressMenuRemote('108');">
+	<area shape="rect" coords="25,286,38,315" title="left" onclick="pressMenuRemote('105');">
+	<area shape="rect" coords="71,286,82,315" title="right" onclick="pressMenuRemote('106');">
+	<area shape="circle" coords="54,302,9" title="OK" onclick="pressMenuRemote('352');">
 
 	<area shape="rect" coords="73,45,85,58" title="mute" onclick="pressMenuRemote('113');">
-	<area shape="rect" coords="21,44,35,59" id ="116" title="Power" onclick="pressMenuRemote('116');">
+	<area shape="rect" coords="21,44,35,59" title="Power" onclick="pressMenuRemote('116');">
 
 
-	<area shape="rect" coords="21,103,36,114" id ="2" title="1" onclick="pressMenuRemote('2');">
-	<area shape="rect" coords="46,103,62,114" id ="3" title="2" onclick="pressMenuRemote('3');">
-	<area shape="rect" coords="72,103,88,114" id ="4" title="3" onclick="pressMenuRemote('4');">
-	<area shape="rect" coords="21,124,36,135" id ="5" title="4" onclick="pressMenuRemote('5');">
-	<area shape="rect" coords="46,124,62,135" id ="6" title="5" onclick="pressMenuRemote('6');">
-	<area shape="rect" coords="72,124,88,135" id ="7" title="6" onclick="pressMenuRemote('7');">
-	<area shape="rect" coords="21,144,36,155" id ="8" title="7" onclick="pressMenuRemote('8');">
-	<area shape="rect" coords="46,144,62,155" id ="9" title="8" onclick="pressMenuRemote('9');">
-	<area shape="rect" coords="72,144,88,155" id ="10" title="9" onclick="pressMenuRemote('10');">
-	<area shape="rect" coords="46,165,62,177" id ="11" title="0" onclick="pressMenuRemote('11');">
+	<area shape="rect" coords="21,103,36,114" title="1" onclick="pressMenuRemote('2');">
+	<area shape="rect" coords="46,103,62,114" title="2" onclick="pressMenuRemote('3');">
+	<area shape="rect" coords="72,103,88,114" title="3" onclick="pressMenuRemote('4');">
+	<area shape="rect" coords="21,124,36,135" title="4" onclick="pressMenuRemote('5');">
+	<area shape="rect" coords="46,124,62,135" title="5" onclick="pressMenuRemote('6');">
+	<area shape="rect" coords="72,124,88,135" title="6" onclick="pressMenuRemote('7');">
+	<area shape="rect" coords="21,144,36,155" title="7" onclick="pressMenuRemote('8');">
+	<area shape="rect" coords="46,144,62,155" title="8" onclick="pressMenuRemote('9');">
+	<area shape="rect" coords="72,144,88,155" title="9" onclick="pressMenuRemote('10');">
+	<area shape="rect" coords="46,165,62,177" title="0" onclick="pressMenuRemote('11');">
 
-	<area shape="rect" coords="20,164,35,177" id ="412" title="previous" onclick="pressMenuRemote('412');">
-	<area shape="rect" coords="72,164,88,177" id ="407" title="next" onclick="pressMenuRemote('407');">
+	<area shape="rect" coords="20,164,35,177" title="previous" onclick="pressMenuRemote('412');">
+	<area shape="rect" coords="72,164,88,177" title="next" onclick="pressMenuRemote('407');">
 
-	<area shape="rect" coords="15,245,30,255" id ="398" title="red" onclick="pressMenuRemote('398');">
-	<area shape="rect" coords="37,245,52,255" id ="399" title="green" onclick="pressMenuRemote('399');">
-	<area shape="rect" coords="57,245,72,255" id ="400" title="yellow" onclick="pressMenuRemote('400');">
-	<area shape="rect" coords="77,245,93,255" id ="401" title="blue" onclick="pressMenuRemote('401');">
+	<area shape="rect" coords="15,245,30,255" title="red" onclick="pressMenuRemote('398');">
+	<area shape="rect" coords="37,245,52,255" title="green" onclick="pressMenuRemote('399');">
+	<area shape="rect" coords="57,245,72,255" title="yellow" onclick="pressMenuRemote('400');">
+	<area shape="rect" coords="77,245,93,255" title="blue" onclick="pressMenuRemote('401');">
 
 	<area shape="rect" coords="73,45,85,58" title="mute" onclick="pressMenuRemote('113');">
-	<area shape="rect" coords="21,44,35,59" id ="116" title="Power" onclick="pressMenuRemote('116');">
-	<area shape="rect" coords="37,349,51,357" id ="388" title="text" onclick="pressMenuRemote('388');">
+	<area shape="rect" coords="21,44,35,59" title="Power" onclick="pressMenuRemote('116');">
+	<area shape="rect" coords="37,349,51,357" title="text" onclick="pressMenuRemote('388');">
 
 	<area shape="circle" coords="21,333,7" title="openSatellites" onclick="pressMenuRemote(381);">
 
@@ -65,20 +65,20 @@
 	<area shape="rect" coords="57,403,72,412" title="timeshiftStop" onclick="pressMenuRemote(128);">
 
 	<!-- Fastforward, rewind -->
-	<area shape="rect" coords="16,387,30,395" id ="168" title="rewind" onclick="pressMenuRemote('168');">
-	<area shape="rect" coords="37,387,51,395" id ="207" title="play" onclick="pressMenuRemote('207');">
-	<area shape="rect" coords="57,387,72,395" id ="119" title="pause" onclick="pressMenuRemote('119');">
-	<area shape="rect" coords="78,387,93,395" id ="208" title="forward" onclick="pressMenuRemote('208');">
+	<area shape="rect" coords="16,387,30,395" title="rewind" onclick="pressMenuRemote('168');">
+	<area shape="rect" coords="37,387,51,395" title="play" onclick="pressMenuRemote('207');">
+	<area shape="rect" coords="57,387,72,395" title="pause" onclick="pressMenuRemote('119');">
+	<area shape="rect" coords="78,387,93,395" title="forward" onclick="pressMenuRemote('208');">
 
 	<!-- Key Radio, and Tv -->
 	<area shape="rect" coords="78,404,93,412" title="radio" onclick="pressMenuRemote(385);">
 	<area shape="rect" coords="16,404,30,412" title="tv" onclick="pressMenuRemote(377);">
-	<area shape="rect" coords="37,404,51,412" id ="167" title="record" onclick="pressMenuRemote('167');">
+	<area shape="rect" coords="37,404,51,412" title="record" onclick="pressMenuRemote('167');">
 
-	<area shape="rect" coords="71,85,89,97" id ="376" title="Lan" onclick="pressMenuRemote('376');">
-	<area shape="rect" coords="57,369,73,379" id ="394" title="ytube" onclick="pressMenuRemote('394');">
-	<area shape="rect" coords="78,368,94,380" id ="375" title="pip" onclick="pressMenuRemote('375');">
-	<area shape="rect" coords="45,85,64,97" id ="371" title="showRFmod" onclick="pressMenuRemote('371');">
-	<area shape="circle" coords="88,332,8" id ="406" title="prov" onclick="pressMenuRemote('406');">
+	<area shape="rect" coords="71,85,89,97" title="Lan" onclick="pressMenuRemote('376');">
+	<area shape="rect" coords="57,369,73,379" title="ytube" onclick="pressMenuRemote('394');">
+	<area shape="rect" coords="78,368,94,380" title="pip" onclick="pressMenuRemote('375');">
+	<area shape="rect" coords="45,85,64,97" title="showRFmod" onclick="pressMenuRemote('371');">
+	<area shape="circle" coords="88,332,8" title="prov" onclick="pressMenuRemote('406');">
 </map>
 

--- a/BoxBranding/remotes/qviart1/remote.html
+++ b/BoxBranding/remotes/qviart1/remote.html
@@ -1,71 +1,71 @@
 <img border='0' src='/static/remotes/qviart1/rc.png' usemap='#map' >
 <map name="map">
 	<!-- brand: qviart(lunix, lunix3-4k) -->
-	<area shape="rect" coords="31, 24, 50, 45" id ="116" title="Power" onclick="pressMenuRemote('116');">
-	<area shape="rect" coords="89, 27,104, 42" id ="113" title="mute" onclick="pressMenuRemote('113');">
+	<area shape="rect" coords="31, 24, 50, 45" title="Power" onclick="pressMenuRemote('116');">
+	<area shape="rect" coords="89, 27,104, 42" title="mute" onclick="pressMenuRemote('113');">
 		
-	<area shape="rect" coords="30, 53, 52, 66" id ="138" title="help" onclick="pressMenuRemote('138');">
-	<area shape="rect" coords="58, 53, 80, 66" id ="102" title="home" onclick="pressMenuRemote('102');">
-	<area shape="rect" coords="86, 53,109, 66" id ="376" title="Lan" onclick="pressMenuRemote('376');">
+	<area shape="rect" coords="30, 53, 52, 66" title="help" onclick="pressMenuRemote('138');">
+	<area shape="rect" coords="58, 53, 80, 66" title="home" onclick="pressMenuRemote('102');">
+	<area shape="rect" coords="86, 53,109, 66" title="Lan" onclick="pressMenuRemote('376');">
 
-	<area shape="rect" coords="30, 73, 52, 85" id ="372" title="ZoomInOut" onclick="pressMenuRemote('372');">
-	<area shape="rect" coords="58, 73, 80, 85" id ="107" title="end" onclick="pressMenuRemote('107');">
-	<area shape="rect" coords="86, 73,108, 85" id ="394" title="plugin" onclick="pressMenuRemote('394');">
+	<area shape="rect" coords="30, 73, 52, 85" title="ZoomInOut" onclick="pressMenuRemote('372');">
+	<area shape="rect" coords="58, 73, 80, 85" title="end" onclick="pressMenuRemote('107');">
+	<area shape="rect" coords="86, 73,108, 85" title="plugin" onclick="pressMenuRemote('394');">
 
-	<area shape="rect" coords="31, 91, 51,108" id ="2" title="1" onclick="pressMenuRemote('2');">
-	<area shape="rect" coords="58, 91, 79,108" id ="3" title="2" onclick="pressMenuRemote('3');">
-	<area shape="rect" coords="87, 91,108,108" id ="4" title="3" onclick="pressMenuRemote('4');">
-	<area shape="rect" coords="31,114, 51,130" id ="5" title="4" onclick="pressMenuRemote('5');">
-	<area shape="rect" coords="58,114, 79,130" id ="6" title="5" onclick="pressMenuRemote('6');">
-	<area shape="rect" coords="87,114,108,130" id ="7" title="6" onclick="pressMenuRemote('7');">
-	<area shape="rect" coords="31,137, 51,151" id ="8" title="7" onclick="pressMenuRemote('8');">
-	<area shape="rect" coords="58,137, 79,151" id ="9" title="8" onclick="pressMenuRemote('9');">
-	<area shape="rect" coords="87,137,108,151" id ="10" title="9" onclick="pressMenuRemote('10');">
-	<area shape="rect" coords="31,160, 51,174" id ="412" title="previous" onclick="pressMenuRemote('412');">
-	<area shape="rect" coords="58,160, 81,174" id ="11" title="0" onclick="pressMenuRemote('11');">
-	<area shape="rect" coords="87,160,108,174" id ="407" title="next" onclick="pressMenuRemote('407');">
+	<area shape="rect" coords="31, 91, 51,108" title="1" onclick="pressMenuRemote('2');">
+	<area shape="rect" coords="58, 91, 79,108" title="2" onclick="pressMenuRemote('3');">
+	<area shape="rect" coords="87, 91,108,108" title="3" onclick="pressMenuRemote('4');">
+	<area shape="rect" coords="31,114, 51,130" title="4" onclick="pressMenuRemote('5');">
+	<area shape="rect" coords="58,114, 79,130" title="5" onclick="pressMenuRemote('6');">
+	<area shape="rect" coords="87,114,108,130" title="6" onclick="pressMenuRemote('7');">
+	<area shape="rect" coords="31,137, 51,151" title="7" onclick="pressMenuRemote('8');">
+	<area shape="rect" coords="58,137, 79,151" title="8" onclick="pressMenuRemote('9');">
+	<area shape="rect" coords="87,137,108,151" title="9" onclick="pressMenuRemote('10');">
+	<area shape="rect" coords="31,160, 51,174" title="previous" onclick="pressMenuRemote('412');">
+	<area shape="rect" coords="58,160, 81,174" title="0" onclick="pressMenuRemote('11');">
+	<area shape="rect" coords="87,160,108,174" title="next" onclick="pressMenuRemote('407');">
 
-	<area shape="rect" coords="27,185, 52,208" id ="115" title="volume up" onclick="pressMenuRemote('115');">
-	<area shape="rect" coords="27,215, 52,238" id ="114" title="volume down" onclick="pressMenuRemote('114');">
-	<area shape="rect" coords="87,185,110,208" id ="402" title="channelup" onclick="pressMenuRemote('402');">
-	<area shape="rect" coords="87,215,110,238" id ="403" title="channeldown" onclick="pressMenuRemote('403');">
-	<area shape="rect" coords="61,189, 78,206" id ="365" title="EPGPressed" onclick="pressMenuRemote('365');">
-	<area shape="rect" coords="61,218, 78,233" id ="358" title="info" onclick="pressMenuRemote('358');">
+	<area shape="rect" coords="27,185, 52,208" title="volume up" onclick="pressMenuRemote('115');">
+	<area shape="rect" coords="27,215, 52,238" title="volume down" onclick="pressMenuRemote('114');">
+	<area shape="rect" coords="87,185,110,208" title="channelup" onclick="pressMenuRemote('402');">
+	<area shape="rect" coords="87,215,110,238" title="channeldown" onclick="pressMenuRemote('403');">
+	<area shape="rect" coords="61,189, 78,206" title="EPGPressed" onclick="pressMenuRemote('365');">
+	<area shape="rect" coords="61,218, 78,233" title="info" onclick="pressMenuRemote('358');">
 
-	<area shape="rect" coords="26,248, 45,261" id ="392" title="audio" onclick="pressMenuRemote('392');">
-	<area shape="rect" coords="48,248, 66,261" id ="388" title="startTeletext" onclick="pressMenuRemote('388');">
-	<area shape="rect" coords="71,248, 89,261" id ="370" title="subtitle" onclick="pressMenuRemote('370');">
-	<area shape="rect" coords="93,248,110,261" id ="362" title="openTimerList" onclick="pressMenuRemote('362');">
+	<area shape="rect" coords="26,248, 45,261" title="audio" onclick="pressMenuRemote('392');">
+	<area shape="rect" coords="48,248, 66,261" title="startTeletext" onclick="pressMenuRemote('388');">
+	<area shape="rect" coords="71,248, 89,261" title="subtitle" onclick="pressMenuRemote('370');">
+	<area shape="rect" coords="93,248,110,261" title="openTimerList" onclick="pressMenuRemote('362');">
 
-	<area shape="rect" coords="25,268, 41,284" id ="139" title="menu" onclick="pressMenuRemote('139');">
-	<area shape="rect" coords="97,268,113,284" id ="174" title="exit" onclick="pressMenuRemote('174');">
-	<area shape="rect" coords="25,335, 41,351" id ="381" title="openSatellites" onclick="pressMenuRemote('381');">
-	<area shape="rect" coords="97,335,113,351" id ="406" title="prov" onclick="pressMenuRemote('406');">
+	<area shape="rect" coords="25,268, 41,284" title="menu" onclick="pressMenuRemote('139');">
+	<area shape="rect" coords="97,268,113,284" title="exit" onclick="pressMenuRemote('174');">
+	<area shape="rect" coords="25,335, 41,351" title="openSatellites" onclick="pressMenuRemote('381');">
+	<area shape="rect" coords="97,335,113,351" title="prov" onclick="pressMenuRemote('406');">
 
-	<area shape="rect" coords="49,277, 88,293" id ="103" title="up" onclick="pressMenuRemote('103');">
-	<area shape="rect" coords="51,328, 86,344" id ="108" title="down" onclick="pressMenuRemote('108');">
-	<area shape="rect" coords="36,294, 52,326" id ="105" title="left" onclick="pressMenuRemote('105');">
-	<area shape="rect" coords="83,294,103,326" id ="106" title="right" onclick="pressMenuRemote('106');">
-	<area shape="rect" coords="56,298, 81,322" id ="352" title="OK" onclick="pressMenuRemote('352');">
+	<area shape="rect" coords="49,277, 88,293" title="up" onclick="pressMenuRemote('103');">
+	<area shape="rect" coords="51,328, 86,344" title="down" onclick="pressMenuRemote('108');">
+	<area shape="rect" coords="36,294, 52,326" title="left" onclick="pressMenuRemote('105');">
+	<area shape="rect" coords="83,294,103,326" title="right" onclick="pressMenuRemote('106');">
+	<area shape="rect" coords="56,298, 81,322" title="OK" onclick="pressMenuRemote('352');">
 
-	<area shape="rect" coords="25,360, 45,372" id ="398" title="red" onclick="pressMenuRemote('398');">
-	<area shape="rect" coords="48,360, 67,372" id ="399" title="green" onclick="pressMenuRemote('399');">
-	<area shape="rect" coords="71,360, 89,372" id ="400" title="yellow" onclick="pressMenuRemote('400');">
-	<area shape="rect" coords="93,360,113,372" id ="401" title="blue" onclick="pressMenuRemote('401');">
+	<area shape="rect" coords="25,360, 45,372" title="red" onclick="pressMenuRemote('398');">
+	<area shape="rect" coords="48,360, 67,372" title="green" onclick="pressMenuRemote('399');">
+	<area shape="rect" coords="71,360, 89,372" title="yellow" onclick="pressMenuRemote('400');">
+	<area shape="rect" coords="93,360,113,372" title="blue" onclick="pressMenuRemote('401');">
 
-	<area shape="rect" coords="25,383, 45,394" id ="393" title="showMovies" onclick="pressMenuRemote('393');">
-	<area shape="rect" coords="48,383, 67,394" id ="395" title="showMediaPlayer" onclick="pressMenuRemote('395');">
-	<area shape="rect" coords="71,383, 89,394" id ="59" title="f1" onclick="pressMenuRemote('59');">
-	<area shape="rect" coords="93,383,113,394" id ="60" title="f2" onclick="pressMenuRemote('60');">
+	<area shape="rect" coords="25,383, 45,394" title="showMovies" onclick="pressMenuRemote('393');">
+	<area shape="rect" coords="48,383, 67,394" title="showMediaPlayer" onclick="pressMenuRemote('395');">
+	<area shape="rect" coords="71,383, 89,394" title="f1" onclick="pressMenuRemote('59');">
+	<area shape="rect" coords="93,383,113,394" title="f2" onclick="pressMenuRemote('60');">
 
-	<area shape="rect" coords="25,400, 44,412" id ="168" title="rewind" onclick="pressMenuRemote('168');">
-	<area shape="rect" coords="48,400, 67,412" id ="207" title="play" onclick="pressMenuRemote('207');">
-	<area shape="rect" coords="71,400, 89,412" id ="119" title="pause" onclick="pressMenuRemote('119');">
-	<area shape="rect" coords="71,400, 89,412" id ="164" title="timeshiftStart" onclick="pressMenuRemote('164');">
-	<area shape="rect" coords="93,400,113,412" id ="208" title="forward" onclick="pressMenuRemote('208');">
+	<area shape="rect" coords="25,400, 44,412" title="rewind" onclick="pressMenuRemote('168');">
+	<area shape="rect" coords="48,400, 67,412" title="play" onclick="pressMenuRemote('207');">
+	<area shape="rect" coords="71,400, 89,412" title="pause" onclick="pressMenuRemote('119');">
+	<area shape="rect" coords="71,400, 89,412" title="timeshiftStart" onclick="pressMenuRemote('164');">
+	<area shape="rect" coords="93,400,113,412" title="forward" onclick="pressMenuRemote('208');">
 
-	<area shape="rect" coords="25,418, 44,430" id ="377" title="tv" onclick="pressMenuRemote('377');">
-	<area shape="rect" coords="48,418, 67,430" id ="167" title="record" onclick="pressMenuRemote('167');">
-	<area shape="rect" coords="71,418, 89,430" id ="128" title="timeshiftStop" onclick="pressMenuRemote('128');">	
-	<area shape="rect" coords="93,418,113,430" id ="385" title="radio" onclick="pressMenuRemote('385');">
+	<area shape="rect" coords="25,418, 44,430" title="tv" onclick="pressMenuRemote('377');">
+	<area shape="rect" coords="48,418, 67,430" title="record" onclick="pressMenuRemote('167');">
+	<area shape="rect" coords="71,418, 89,430" title="timeshiftStop" onclick="pressMenuRemote('128');">	
+	<area shape="rect" coords="93,418,113,430" title="radio" onclick="pressMenuRemote('385');">
 </map>

--- a/BoxBranding/remotes/qviart2/remote.html
+++ b/BoxBranding/remotes/qviart2/remote.html
@@ -1,40 +1,40 @@
 <img border='0' src='/static/remotes/qviart2/rc.png' usemap='#map' >
 <map name="map">
 	<area shape="rect" coords="14,19,39,33" title="mute" onclick="pressMenuRemote('113');">
-	<area shape="rect" coords="87,16,107,35" id ="116" title="Power" onclick="pressMenuRemote('116');">
-	<area shape="rect" coords="14,65,40,79" id ="388" title="text" onclick="pressMenuRemote('388');">
-	<area shape="rect" coords="47,66,73,79" id ="370" title="subtitle" onclick="pressMenuRemote('370');">
-	<area shape="rect" coords="47,44,74,59" id ="172" title="home" onclick="pressMenuRemote('172');">
-	<area shape="rect" coords="80,44,104,59" id ="107" title="end" onclick="pressMenuRemote('107');">
+	<area shape="rect" coords="87,16,107,35" title="Power" onclick="pressMenuRemote('116');">
+	<area shape="rect" coords="14,65,40,79" title="text" onclick="pressMenuRemote('388');">
+	<area shape="rect" coords="47,66,73,79" title="subtitle" onclick="pressMenuRemote('370');">
+	<area shape="rect" coords="47,44,74,59" title="home" onclick="pressMenuRemote('172');">
+	<area shape="rect" coords="80,44,104,59" title="end" onclick="pressMenuRemote('107');">
 
-	<area shape="rect" coords="13,258,40,279" id ="2" title="1" onclick="pressMenuRemote('2');">
-	<area shape="rect" coords="47,258,74,279" id ="3" title="2" onclick="pressMenuRemote('3');">
-	<area shape="rect" coords="81,258,109,279" id ="4" title="3" onclick="pressMenuRemote('4');">
-	<area shape="rect" coords="13,287,40,307" id ="5" title="4" onclick="pressMenuRemote('5');">
-	<area shape="rect" coords="47,287,74,307" id ="6" title="5" onclick="pressMenuRemote('6');">
-	<area shape="rect" coords="81,287,109,307" id ="7" title="6" onclick="pressMenuRemote('7');">
-	<area shape="rect" coords="13,315,40,337" id ="8" title="7" onclick="pressMenuRemote('8');">
-	<area shape="rect" coords="47,315,74,337" id ="9" title="8" onclick="pressMenuRemote('9');">
-	<area shape="rect" coords="81,315,109,337" id ="10" title="9" onclick="pressMenuRemote('10');">
-	<area shape="rect" coords="47,344,74,364" id ="11" title="0" onclick="pressMenuRemote('11');">
+	<area shape="rect" coords="13,258,40,279" title="1" onclick="pressMenuRemote('2');">
+	<area shape="rect" coords="47,258,74,279" title="2" onclick="pressMenuRemote('3');">
+	<area shape="rect" coords="81,258,109,279" title="3" onclick="pressMenuRemote('4');">
+	<area shape="rect" coords="13,287,40,307" title="4" onclick="pressMenuRemote('5');">
+	<area shape="rect" coords="47,287,74,307" title="5" onclick="pressMenuRemote('6');">
+	<area shape="rect" coords="81,287,109,307" title="6" onclick="pressMenuRemote('7');">
+	<area shape="rect" coords="13,315,40,337" title="7" onclick="pressMenuRemote('8');">
+	<area shape="rect" coords="47,315,74,337" title="8" onclick="pressMenuRemote('9');">
+	<area shape="rect" coords="81,315,109,337" title="9" onclick="pressMenuRemote('10');">
+	<area shape="rect" coords="47,344,74,364" title="0" onclick="pressMenuRemote('11');">
 
 	<!-- Added Key -->
 	<!--<area shape="rect" coords="96,95,118,107" title="Lan" onclick="pressMenuRemote(59);">-->
-	<area shape="circle" coords="98,179,10" id ="174" title="exit" onclick="pressMenuRemote('174');">
+	<area shape="circle" coords="98,179,10" title="exit" onclick="pressMenuRemote('174');">
 
-	<area shape="rect" coords="80,109,107,133" id ="402" title="channelup" onclick="pressMenuRemote('402');">
-	<area shape="rect" coords="80,137,107,162" id ="403" title="channeldown" onclick="pressMenuRemote('403');">
+	<area shape="rect" coords="80,109,107,133" title="channelup" onclick="pressMenuRemote('402');">
+	<area shape="rect" coords="80,137,107,162" title="channeldown" onclick="pressMenuRemote('403');">
 
-	<area shape="rect" coords="14,109,40,133" id ="115" title="volume up" onclick="pressMenuRemote('115');">
-	<area shape="rect" coords="14,137,40,162" id ="114" title="volume down" onclick="pressMenuRemote('114');">
+	<area shape="rect" coords="14,109,40,133" title="volume up" onclick="pressMenuRemote('115');">
+	<area shape="rect" coords="14,137,40,162" title="volume down" onclick="pressMenuRemote('114');">
 
-	<area shape="rect" coords="13,343,41,364" id ="412" title="previous" onclick="pressMenuRemote('412');">
-	<area shape="rect" coords="80,343,108,364" id ="407" title="next" onclick="pressMenuRemote('407');">
+	<area shape="rect" coords="13,343,41,364" title="previous" onclick="pressMenuRemote('412');">
+	<area shape="rect" coords="80,343,108,364" title="next" onclick="pressMenuRemote('407');">
 
-	<area shape="rect" coords="14,375,32,392" id ="398" title="red" onclick="pressMenuRemote('398');">
-	<area shape="rect" coords="38,375,57,392" id ="399" title="green" onclick="pressMenuRemote('399');">
-	<area shape="rect" coords="64,375,83,392" id ="400" title="yellow" onclick="pressMenuRemote('400');">
-	<area shape="rect" coords="89,375,108,392" id ="401" title="blue" onclick="pressMenuRemote('401');">
+	<area shape="rect" coords="14,375,32,392" title="red" onclick="pressMenuRemote('398');">
+	<area shape="rect" coords="38,375,57,392" title="green" onclick="pressMenuRemote('399');">
+	<area shape="rect" coords="64,375,83,392" title="yellow" onclick="pressMenuRemote('400');">
+	<area shape="rect" coords="89,375,108,392" title="blue" onclick="pressMenuRemote('401');">
 
 	<area shape="rect" coords="48,115,73,129" title="EPGPressed" onclick="pressMenuRemote(365);">
 	<area shape="circle" coords="22,244,10" title="openSatellites" onclick="pressMenuRemote(381);">
@@ -66,76 +66,76 @@
 
 	<!-- Rf modulator -->
 	<!--<area shape="rect" coords="98,114,116,124" title="showRFmod" onclick="pressMenuRemote(63);">-->
-	<area shape="circle" coords="99,244,10" id ="358" title="Info" onclick="pressMenuRemote('358');">
+	<area shape="circle" coords="99,244,10" title="Info" onclick="pressMenuRemote('358');">
 
-	<area shape="circle" coords="61,184,7" id ="103" title="up" onclick="pressMenuRemote('103');">
-	<area shape="circle" coords="61,238,7" id ="108" title="down" onclick="pressMenuRemote('108');">
-	<area shape="circle" coords="33,211,7" id ="105" title="left" onclick="pressMenuRemote('105');">
-	<area shape="circle" coords="86,211,7" id ="106" title="right" onclick="pressMenuRemote('106');">
+	<area shape="circle" coords="61,184,7" title="up" onclick="pressMenuRemote('103');">
+	<area shape="circle" coords="61,238,7" title="down" onclick="pressMenuRemote('108');">
+	<area shape="circle" coords="33,211,7" title="left" onclick="pressMenuRemote('105');">
+	<area shape="circle" coords="86,211,7" title="right" onclick="pressMenuRemote('106');">
 
-	<area shape="circle" coords="61,211,15" id ="352" title="OK" onclick="pressMenuRemote('352');">
-	<area shape="rect" coords="47,143,72,157" id ="392" title="audio" onclick="pressMenuRemote('392');">
+	<area shape="circle" coords="61,211,15" title="OK" onclick="pressMenuRemote('352');">
+	<area shape="rect" coords="47,143,72,157" title="audio" onclick="pressMenuRemote('392');">
 
-	<area shape="circle" coords="22,178,10" id ="139" title="menu" onclick="pressMenuRemote('139');">
-	<area shape="rect" coords="38,423,57,441" id ="167" title="record" onclick="pressMenuRemote('167');">
-	<area shape="rect" coords="13,86,40,100" id ="393" title="videoaltlast" onclick="pressMenuRemote('393');">
+	<area shape="circle" coords="22,178,10" title="menu" onclick="pressMenuRemote('139');">
+	<area shape="rect" coords="38,423,57,441" title="record" onclick="pressMenuRemote('167');">
+	<area shape="rect" coords="13,86,40,100" title="videoaltlast" onclick="pressMenuRemote('393');">
 
-	<area shape="rect" coords="13,44,40,59" id ="138" title="help" onclick="pressMenuRemote('138');">
+	<area shape="rect" coords="13,44,40,59" title="help" onclick="pressMenuRemote('138');">
 
-	<area shape="rect" coords="14,400,32,417" id ="168" title="rewind" onclick="pressMenuRemote('168');">
-	<area shape="rect" coords="38,400,58,417" id ="207" title="play" onclick="pressMenuRemote('207');">
-	<area shape="rect" coords="64,400,82,417" id ="119" title="pause" onclick="pressMenuRemote('119');">
-	<area shape="rect" coords="89,400,107,417" id ="208" title="forward" onclick="pressMenuRemote('208');">
-	<area shape="rect" coords="13,424,31,441" id ="377" title="tv" onclick="pressMenuRemote('377');">
+	<area shape="rect" coords="14,400,32,417" title="rewind" onclick="pressMenuRemote('168');">
+	<area shape="rect" coords="38,400,58,417" title="play" onclick="pressMenuRemote('207');">
+	<area shape="rect" coords="64,400,82,417" title="pause" onclick="pressMenuRemote('119');">
+	<area shape="rect" coords="89,400,107,417" title="forward" onclick="pressMenuRemote('208');">
+	<area shape="rect" coords="13,424,31,441" title="tv" onclick="pressMenuRemote('377');">
 
 
-	<area shape="rect" coords="63,424,82,440" id ="128" title="stop" onclick="pressMenuRemote('128');">
-	<area shape="circle" coords="90,424,107,440" id ="385" title="radio" onclick="pressMenuRemote('385');">
+	<area shape="rect" coords="63,424,82,440" title="stop" onclick="pressMenuRemote('128');">
+	<area shape="circle" coords="90,424,107,440" title="radio" onclick="pressMenuRemote('385');">
 </map>
 <!--
 	<area shape="circle" coords="33,28,15" title="mute" onclick="pressMenuRemote('113');">
-	<area shape="circle" coords="105,28,15" id ="116" title="Power" onclick="pressMenuRemote('116');">
-	<area shape="circle" coords="33,53,15" id ="388" title="text" onclick="pressMenuRemote('388');">
-	<area shape="circle" coords="58,53,15" id ="370" title="subtitle" onclick="pressMenuRemote('370');">
-	<area shape="circle" coords="82,53,15" id ="102" title="home" onclick="pressMenuRemote('102');">
-	<area shape="circle" coords="105,53,15" id ="107" title="end" onclick="pressMenuRemote('107');">
-	<area shape="circle" coords="38,79,15" id ="2" title="1" onclick="pressMenuRemote('2');">
-	<area shape="circle" coords="70,79,15" id ="3" title="2" onclick="pressMenuRemote('3');">
-	<area shape="circle" coords="102,79,15" id ="4" title="3" onclick="pressMenuRemote('4');">
-	<area shape="circle" coords="38,106,15" id ="5" title="4" onclick="pressMenuRemote('5');">
-	<area shape="circle" coords="70,106,15" id ="6" title="5" onclick="pressMenuRemote('6');">
-	<area shape="circle" coords="102,106,15" id ="7" title="6" onclick="pressMenuRemote('7');">
-	<area shape="circle" coords="38,133,15" id ="8" title="7" onclick="pressMenuRemote('8');">
-	<area shape="circle" coords="70,133,15" id ="9" title="8" onclick="pressMenuRemote('9');">
-	<area shape="circle" coords="102,133,15" id ="10" title="9" onclick="pressMenuRemote('10');">
-	<area shape="circle" coords="38,161,15" id ="412" title="previous" onclick="pressMenuRemote('412');">
-	<area shape="circle" coords="70,161,15" id ="11" title="0" onclick="pressMenuRemote('11');">
-	<area shape="circle" coords="102,161,15" id ="407" title="next" onclick="pressMenuRemote('407');">
-	<area shape="circle" coords="33,186,15" id ="398" title="red" onclick="pressMenuRemote('398');">
-	<area shape="circle" coords="58,186,15" id ="399" title="green" onclick="pressMenuRemote('399');">
-	<area shape="circle" coords="82,186,15" id ="400" title="yellow" onclick="pressMenuRemote('400');">
-	<area shape="circle" coords="105,186,15" id ="401" title="blue" onclick="pressMenuRemote('401');">
-	<area shape="circle" coords="70,213,15" id ="103" title="up" onclick="pressMenuRemote('103');">
-	<area shape="circle" coords="70,283,15" id ="108" title="down" onclick="pressMenuRemote('108');">
-	<area shape="circle" coords="35,248,15" id ="105" title="left" onclick="pressMenuRemote('105');">
-	<area shape="circle" coords="105,248,15" id ="106" title="right" onclick="pressMenuRemote('106');">
-	<area shape="circle" coords="70,248,20" id ="352" title="OK" onclick="pressMenuRemote('352');">
-	<area shape="circle" coords="40,307,15" id ="115" title="volume up" onclick="pressMenuRemote('115');">
-	<area shape="circle" coords="40,338,13" id ="114" title="volume down" onclick="pressMenuRemote('114');">
-	<area shape="circle" coords="70,310,15" id ="174" title="exit" onclick="pressMenuRemote('174');">
-	<area shape="circle" coords="70,334,15" id ="358" title="epg" onclick="pressMenuRemote('358');">
-	<area shape="circle" coords="99,307,15" id ="402" title="channelup" onclick="pressMenuRemote('402');">
-	<area shape="circle" coords="99,338,15" id ="403" title="channeldown" onclick="pressMenuRemote('403');">
-	<area shape="circle" coords="36,362,15" id ="139" title="menu" onclick="pressMenuRemote('139');">
-	<area shape="circle" coords="59,362,15" id ="393" title="videoaltlast" onclick="pressMenuRemote('393');">
-	<area shape="circle" coords="81,362,15" id ="392" title="audio" onclick="pressMenuRemote('392');">
-	<area shape="circle" coords="104,362,15" id ="138" title="help" onclick="pressMenuRemote('138');">
-	<area shape="circle" coords="36,383,15" id ="168" title="rewind" onclick="pressMenuRemote('168');">
-	<area shape="circle" coords="59,383,15" id ="207" title="play" onclick="pressMenuRemote('207');">
-	<area shape="circle" coords="81,383,15" id ="119" title="pause" onclick="pressMenuRemote('119');">
-	<area shape="circle" coords="104,383,15" id ="208" title="forward" onclick="pressMenuRemote('208');">
-	<area shape="circle" coords="36,405,15" id ="377" title="tv" onclick="pressMenuRemote('377');">
-	<area shape="circle" coords="59,405,15" id ="167" title="record" onclick="pressMenuRemote('167');">
-	<area shape="circle" coords="81,405,15" id ="128" title="stop" onclick="pressMenuRemote('128');">
-	<area shape="circle" coords="104,405,15" id ="385" title="radio" onclick="pressMenuRemote('385');">
+	<area shape="circle" coords="105,28,15" title="Power" onclick="pressMenuRemote('116');">
+	<area shape="circle" coords="33,53,15" title="text" onclick="pressMenuRemote('388');">
+	<area shape="circle" coords="58,53,15" title="subtitle" onclick="pressMenuRemote('370');">
+	<area shape="circle" coords="82,53,15" title="home" onclick="pressMenuRemote('102');">
+	<area shape="circle" coords="105,53,15" title="end" onclick="pressMenuRemote('107');">
+	<area shape="circle" coords="38,79,15" title="1" onclick="pressMenuRemote('2');">
+	<area shape="circle" coords="70,79,15" title="2" onclick="pressMenuRemote('3');">
+	<area shape="circle" coords="102,79,15" title="3" onclick="pressMenuRemote('4');">
+	<area shape="circle" coords="38,106,15" title="4" onclick="pressMenuRemote('5');">
+	<area shape="circle" coords="70,106,15" title="5" onclick="pressMenuRemote('6');">
+	<area shape="circle" coords="102,106,15" title="6" onclick="pressMenuRemote('7');">
+	<area shape="circle" coords="38,133,15" title="7" onclick="pressMenuRemote('8');">
+	<area shape="circle" coords="70,133,15" title="8" onclick="pressMenuRemote('9');">
+	<area shape="circle" coords="102,133,15" title="9" onclick="pressMenuRemote('10');">
+	<area shape="circle" coords="38,161,15" title="previous" onclick="pressMenuRemote('412');">
+	<area shape="circle" coords="70,161,15" title="0" onclick="pressMenuRemote('11');">
+	<area shape="circle" coords="102,161,15" title="next" onclick="pressMenuRemote('407');">
+	<area shape="circle" coords="33,186,15" title="red" onclick="pressMenuRemote('398');">
+	<area shape="circle" coords="58,186,15" title="green" onclick="pressMenuRemote('399');">
+	<area shape="circle" coords="82,186,15" title="yellow" onclick="pressMenuRemote('400');">
+	<area shape="circle" coords="105,186,15" title="blue" onclick="pressMenuRemote('401');">
+	<area shape="circle" coords="70,213,15" title="up" onclick="pressMenuRemote('103');">
+	<area shape="circle" coords="70,283,15" title="down" onclick="pressMenuRemote('108');">
+	<area shape="circle" coords="35,248,15" title="left" onclick="pressMenuRemote('105');">
+	<area shape="circle" coords="105,248,15" title="right" onclick="pressMenuRemote('106');">
+	<area shape="circle" coords="70,248,20" title="OK" onclick="pressMenuRemote('352');">
+	<area shape="circle" coords="40,307,15" title="volume up" onclick="pressMenuRemote('115');">
+	<area shape="circle" coords="40,338,13" title="volume down" onclick="pressMenuRemote('114');">
+	<area shape="circle" coords="70,310,15" title="exit" onclick="pressMenuRemote('174');">
+	<area shape="circle" coords="70,334,15" title="epg" onclick="pressMenuRemote('358');">
+	<area shape="circle" coords="99,307,15" title="channelup" onclick="pressMenuRemote('402');">
+	<area shape="circle" coords="99,338,15" title="channeldown" onclick="pressMenuRemote('403');">
+	<area shape="circle" coords="36,362,15" title="menu" onclick="pressMenuRemote('139');">
+	<area shape="circle" coords="59,362,15" title="videoaltlast" onclick="pressMenuRemote('393');">
+	<area shape="circle" coords="81,362,15" title="audio" onclick="pressMenuRemote('392');">
+	<area shape="circle" coords="104,362,15" title="help" onclick="pressMenuRemote('138');">
+	<area shape="circle" coords="36,383,15" title="rewind" onclick="pressMenuRemote('168');">
+	<area shape="circle" coords="59,383,15" title="play" onclick="pressMenuRemote('207');">
+	<area shape="circle" coords="81,383,15" title="pause" onclick="pressMenuRemote('119');">
+	<area shape="circle" coords="104,383,15" title="forward" onclick="pressMenuRemote('208');">
+	<area shape="circle" coords="36,405,15" title="tv" onclick="pressMenuRemote('377');">
+	<area shape="circle" coords="59,405,15" title="record" onclick="pressMenuRemote('167');">
+	<area shape="circle" coords="81,405,15" title="stop" onclick="pressMenuRemote('128');">
+	<area shape="circle" coords="104,405,15" title="radio" onclick="pressMenuRemote('385');">
 	-->

--- a/BoxBranding/remotes/qviart3/remote.html
+++ b/BoxBranding/remotes/qviart3/remote.html
@@ -1,76 +1,76 @@
 <img border='0' src='/static/remotes/qviart3/rc.png' usemap='#map' >
 <map name="map">
 	<!-- brand: spain qviart lunix4k : mk erectronics rcu  -->
-	<area shape="rect" coords=" 24, 23, 40, 39" id ="113" title="mute"            onclick="pressMenuRemote('113');">
-	<area shape="rect" coords=" 84, 23,102, 39" id ="116" title="Power"           onclick="pressMenuRemote('116');">	
+	<area shape="rect" coords=" 24, 23, 40, 39" title="mute"            onclick="pressMenuRemote('113');">
+	<area shape="rect" coords=" 84, 23,102, 39" title="Power"           onclick="pressMenuRemote('116');">	
 		
-	<area shape="rect" coords=" 17, 50, 36, 61" id ="138" title="help"            onclick="pressMenuRemote('138');">	
-	<area shape="rect" coords=" 41, 50, 60, 61" id ="102" title="home"            onclick="pressMenuRemote('102');">	
-	<area shape="rect" coords=" 66, 50, 84, 61" id ="376" title="Lan"             onclick="pressMenuRemote('376');">
-	<area shape="rect" coords=" 90, 50,108, 61" id ="372" title="ZoomInOut"       onclick="pressMenuRemote('372');">
+	<area shape="rect" coords=" 17, 50, 36, 61" title="help"            onclick="pressMenuRemote('138');">	
+	<area shape="rect" coords=" 41, 50, 60, 61" title="home"            onclick="pressMenuRemote('102');">	
+	<area shape="rect" coords=" 66, 50, 84, 61" title="Lan"             onclick="pressMenuRemote('376');">
+	<area shape="rect" coords=" 90, 50,108, 61" title="ZoomInOut"       onclick="pressMenuRemote('372');">
 	
-	<area shape="rect" coords=" 17, 70, 36, 81" id ="107" title="end"             onclick="pressMenuRemote('107');">
-	<area shape="rect" coords=" 41, 70, 60, 81" id ="394" title="ytube"           onclick="pressMenuRemote('394');">
-	<area shape="rect" coords=" 66, 70, 84, 81" id ="362" title="openTimerList"   onclick="pressMenuRemote('362');">
-	<area shape="rect" coords=" 90, 70,108, 81" id ="392" title="audio"           onclick="pressMenuRemote('392');">
+	<area shape="rect" coords=" 17, 70, 36, 81" title="end"             onclick="pressMenuRemote('107');">
+	<area shape="rect" coords=" 41, 70, 60, 81" title="ytube"           onclick="pressMenuRemote('394');">
+	<area shape="rect" coords=" 66, 70, 84, 81" title="openTimerList"   onclick="pressMenuRemote('362');">
+	<area shape="rect" coords=" 90, 70,108, 81" title="audio"           onclick="pressMenuRemote('392');">
 
-	<area shape="rect" coords=" 17, 89, 36,101" id ="398" title="red"             onclick="pressMenuRemote('398');">
-	<area shape="rect" coords=" 41, 89, 60,101" id ="399" title="green"           onclick="pressMenuRemote('399');">
-	<area shape="rect" coords=" 66, 89, 84,101" id ="400" title="yellow"          onclick="pressMenuRemote('400');">
-	<area shape="rect" coords=" 90, 89,108,101" id ="401" title="blue"            onclick="pressMenuRemote('401');">
+	<area shape="rect" coords=" 17, 89, 36,101" title="red"             onclick="pressMenuRemote('398');">
+	<area shape="rect" coords=" 41, 89, 60,101" title="green"           onclick="pressMenuRemote('399');">
+	<area shape="rect" coords=" 66, 89, 84,101" title="yellow"          onclick="pressMenuRemote('400');">
+	<area shape="rect" coords=" 90, 89,108,101" title="blue"            onclick="pressMenuRemote('401');">
 
-	<area shape="rect" coords=" 17,109, 43,123" id ="2"   title="1"               onclick="pressMenuRemote('2');">
-	<area shape="rect" coords=" 50,109, 75,123" id ="3"   title="2"               onclick="pressMenuRemote('3');">	
-	<area shape="rect" coords=" 83,109,108,123" id ="4"   title="3"               onclick="pressMenuRemote('4');">
-	<area shape="rect" coords=" 17,130, 43,144" id ="5"   title="4"               onclick="pressMenuRemote('5');">
-	<area shape="rect" coords=" 50,130, 75,144" id ="6"   title="5"               onclick="pressMenuRemote('6');">
-	<area shape="rect" coords=" 83,130,108,144" id ="7"   title="6"               onclick="pressMenuRemote('7');">
-	<area shape="rect" coords=" 17,150, 43,165" id ="8"   title="7"               onclick="pressMenuRemote('8');">
-	<area shape="rect" coords=" 50,150, 75,165" id ="9"   title="8"               onclick="pressMenuRemote('9');">
-	<area shape="rect" coords=" 83,150,108,165" id ="10"  title="9"               onclick="pressMenuRemote('10');">
-	<area shape="rect" coords=" 50,171, 75,185" id ="11"  title="0"               onclick="pressMenuRemote('11');">
-	<area shape="rect" coords=" 17,171, 43,185" id ="412" title="previous"        onclick="pressMenuRemote('412');">
-	<area shape="rect" coords=" 83,171,108,185" id ="407" title="next"            onclick="pressMenuRemote('407');">
+	<area shape="rect" coords=" 17,109, 43,123"   title="1"               onclick="pressMenuRemote('2');">
+	<area shape="rect" coords=" 50,109, 75,123"   title="2"               onclick="pressMenuRemote('3');">	
+	<area shape="rect" coords=" 83,109,108,123"   title="3"               onclick="pressMenuRemote('4');">
+	<area shape="rect" coords=" 17,130, 43,144"   title="4"               onclick="pressMenuRemote('5');">
+	<area shape="rect" coords=" 50,130, 75,144"   title="5"               onclick="pressMenuRemote('6');">
+	<area shape="rect" coords=" 83,130,108,144"   title="6"               onclick="pressMenuRemote('7');">
+	<area shape="rect" coords=" 17,150, 43,165"   title="7"               onclick="pressMenuRemote('8');">
+	<area shape="rect" coords=" 50,150, 75,165"   title="8"               onclick="pressMenuRemote('9');">
+	<area shape="rect" coords=" 83,150,108,165"  title="9"               onclick="pressMenuRemote('10');">
+	<area shape="rect" coords=" 50,171, 75,185"  title="0"               onclick="pressMenuRemote('11');">
+	<area shape="rect" coords=" 17,171, 43,185" title="previous"        onclick="pressMenuRemote('412');">
+	<area shape="rect" coords=" 83,171,108,185" title="next"            onclick="pressMenuRemote('407');">
 
-	<area shape="rect" coords=" 22,194, 42,211" id ="115" title="volume up"       onclick="pressMenuRemote('115');">
-	<area shape="rect" coords=" 22,224, 43,239" id ="114" title="volume down"     onclick="pressMenuRemote('114');">
-	<area shape="rect" coords=" 82,194,104,211" id ="402" title="channelup"       onclick="pressMenuRemote('402');">
-	<area shape="rect" coords=" 82,224,104,239" id ="403" title="channeldown"     onclick="pressMenuRemote('403');">
-	<area shape="rect" coords=" 53,198, 72,210" id ="365" title="EPGPressed"      onclick="pressMenuRemote('365');">
-	<area shape="rect" coords=" 53,223, 72,235" id ="358" title="info"            onclick="pressMenuRemote('358');">
+	<area shape="rect" coords=" 22,194, 42,211" title="volume up"       onclick="pressMenuRemote('115');">
+	<area shape="rect" coords=" 22,224, 43,239" title="volume down"     onclick="pressMenuRemote('114');">
+	<area shape="rect" coords=" 82,194,104,211" title="channelup"       onclick="pressMenuRemote('402');">
+	<area shape="rect" coords=" 82,224,104,239" title="channeldown"     onclick="pressMenuRemote('403');">
+	<area shape="rect" coords=" 53,198, 72,210" title="EPGPressed"      onclick="pressMenuRemote('365');">
+	<area shape="rect" coords=" 53,223, 72,235" title="info"            onclick="pressMenuRemote('358');">
 
-	<area shape="rect" coords=" 25,254, 39,268" id ="139" title="menu"            onclick="pressMenuRemote('139');">
-	<area shape="rect" coords=" 87,254,100,268" id ="174" title="exit"            onclick="pressMenuRemote('174');">
+	<area shape="rect" coords=" 25,254, 39,268" title="menu"            onclick="pressMenuRemote('139');">
+	<area shape="rect" coords=" 87,254,100,268" title="exit"            onclick="pressMenuRemote('174');">
 
-	<area shape="rect" coords=" 51,255, 76,271" id ="103" title="up"              onclick="pressMenuRemote('103');">
-	<area shape="rect" coords=" 51,307, 76,323" id ="108" title="down"            onclick="pressMenuRemote('108');">
-	<area shape="rect" coords=" 22,279, 42,300" id ="105" title="left"            onclick="pressMenuRemote('105');">
-	<area shape="rect" coords=" 85,279,104,300" id ="106" title="right"           onclick="pressMenuRemote('106');">
-	<area shape="rect" coords=" 49,278, 77,300" id ="352" title="OK"              onclick="pressMenuRemote('352');">
+	<area shape="rect" coords=" 51,255, 76,271" title="up"              onclick="pressMenuRemote('103');">
+	<area shape="rect" coords=" 51,307, 76,323" title="down"            onclick="pressMenuRemote('108');">
+	<area shape="rect" coords=" 22,279, 42,300" title="left"            onclick="pressMenuRemote('105');">
+	<area shape="rect" coords=" 85,279,104,300" title="right"           onclick="pressMenuRemote('106');">
+	<area shape="rect" coords=" 49,278, 77,300" title="OK"              onclick="pressMenuRemote('352');">
 
-	<area shape="rect" coords=" 25,309, 39,323" id ="381" title="openSatellites"  onclick="pressMenuRemote('381');">
-	<area shape="rect" coords=" 87,309,100,323" id ="406" title="prov"            onclick="pressMenuRemote('406');">
+	<area shape="rect" coords=" 25,309, 39,323" title="openSatellites"  onclick="pressMenuRemote('381');">
+	<area shape="rect" coords=" 87,309,100,323" title="prov"            onclick="pressMenuRemote('406');">
 
-	<area shape="rect" coords=" 17,338, 36,351" id ="393" title="showMovies"      onclick="pressMenuRemote('393');">
-	<area shape="rect" coords=" 41,338, 60,351" id ="395" title="showMediaPlayer" onclick="pressMenuRemote('395');">
-	<area shape="rect" coords=" 65,338, 84,351" id ="388" title="startTeletext"   onclick="pressMenuRemote('388');">
-	<area shape="rect" coords=" 90,338,108,351" id ="370" title="subtitle"        onclick="pressMenuRemote('370');">
+	<area shape="rect" coords=" 17,338, 36,351" title="showMovies"      onclick="pressMenuRemote('393');">
+	<area shape="rect" coords=" 41,338, 60,351" title="showMediaPlayer" onclick="pressMenuRemote('395');">
+	<area shape="rect" coords=" 65,338, 84,351" title="startTeletext"   onclick="pressMenuRemote('388');">
+	<area shape="rect" coords=" 90,338,108,351" title="subtitle"        onclick="pressMenuRemote('370');">
 
-	<area shape="rect" coords=" 17,357, 36,370" id ="168" title="rewind"          onclick="pressMenuRemote('168');">
-	<area shape="rect" coords=" 41,357, 60,370" id ="207" title="play"            onclick="pressMenuRemote('207');">
-	<area shape="rect" coords=" 65,357, 84,370" id ="119" title="pause"           onclick="pressMenuRemote('119');">
-	<area shape="rect" coords=" 65,357, 84,370" id ="164" title="timeshiftStart"  onclick="pressMenuRemote('164');">
-	<area shape="rect" coords=" 90,357,108,370" id ="208" title="forward"         onclick="pressMenuRemote('208');">
+	<area shape="rect" coords=" 17,357, 36,370" title="rewind"          onclick="pressMenuRemote('168');">
+	<area shape="rect" coords=" 41,357, 60,370" title="play"            onclick="pressMenuRemote('207');">
+	<area shape="rect" coords=" 65,357, 84,370" title="pause"           onclick="pressMenuRemote('119');">
+	<area shape="rect" coords=" 65,357, 84,370" title="timeshiftStart"  onclick="pressMenuRemote('164');">
+	<area shape="rect" coords=" 90,357,108,370" title="forward"         onclick="pressMenuRemote('208');">
 
-	<area shape="rect" coords=" 17,377, 36,390" id ="377" title="tv"              onclick="pressMenuRemote('377');">
-	<area shape="rect" coords=" 41,377, 60,390" id ="167" title="record"          onclick="pressMenuRemote('167');">
-	<area shape="rect" coords=" 65,377, 84,390" id ="128" title="timeshiftStop"   onclick="pressMenuRemote('128');">	
-	<area shape="rect" coords=" 90,377,108,390" id ="385" title="radio"           onclick="pressMenuRemote('385');">
+	<area shape="rect" coords=" 17,377, 36,390" title="tv"              onclick="pressMenuRemote('377');">
+	<area shape="rect" coords=" 41,377, 60,390" title="record"          onclick="pressMenuRemote('167');">
+	<area shape="rect" coords=" 65,377, 84,390" title="timeshiftStop"   onclick="pressMenuRemote('128');">	
+	<area shape="rect" coords=" 90,377,108,390" title="radio"           onclick="pressMenuRemote('385');">
 
- 	<area shape="rect" coords=" 17,397, 36,409" id =" 59" title="f1"              onclick="pressMenuRemote('59');">
-	<area shape="rect" coords=" 41,397, 60,409" id =" 60" title="f2"              onclick="pressMenuRemote('60');">
-	<area shape="rect" coords=" 65,397, 84,409" id =" 61" title="f3"              onclick="pressMenuRemote('61');">
-	<area shape="rect" coords=" 90,397,108,409" id =" 62" title="f4"              onclick="pressMenuRemote('62');">
+ 	<area shape="rect" coords=" 17,397, 36,409" title="f1"              onclick="pressMenuRemote('59');">
+	<area shape="rect" coords=" 41,397, 60,409" title="f2"              onclick="pressMenuRemote('60');">
+	<area shape="rect" coords=" 65,397, 84,409" title="f3"              onclick="pressMenuRemote('61');">
+	<area shape="rect" coords=" 90,397,108,409" title="f4"              onclick="pressMenuRemote('62');">
 
 
 </map>

--- a/BoxBranding/remotes/qviart4/remote.html
+++ b/BoxBranding/remotes/qviart4/remote.html
@@ -1,76 +1,76 @@
 <img border='0' src='/static/remotes/qviart4/rc.png' usemap='#map' >
 <map name="map">
 	<!-- brand: spain qviart lunixco : mk electronics rcu  -->
-	<area shape="rect" coords=" 24, 23, 40, 39" id ="113" title="mute"            onclick="pressMenuRemote('113');">
-	<area shape="rect" coords=" 84, 23,102, 39" id ="116" title="Power"           onclick="pressMenuRemote('116');">
+	<area shape="rect" coords=" 24, 23, 40, 39" title="mute"            onclick="pressMenuRemote('113');">
+	<area shape="rect" coords=" 84, 23,102, 39" title="Power"           onclick="pressMenuRemote('116');">
 
-	<area shape="rect" coords=" 17, 50, 36, 61" id ="138" title="help"            onclick="pressMenuRemote('138');">
-	<area shape="rect" coords=" 41, 50, 60, 61" id ="102" title="home"            onclick="pressMenuRemote('102');">
-	<area shape="rect" coords=" 66, 50, 84, 61" id ="376" title="Lan"             onclick="pressMenuRemote('376');">
-	<area shape="rect" coords=" 90, 50,108, 61" id ="372" title="ZoomInOut"       onclick="pressMenuRemote('372');">
+	<area shape="rect" coords=" 17, 50, 36, 61" title="help"            onclick="pressMenuRemote('138');">
+	<area shape="rect" coords=" 41, 50, 60, 61" title="home"            onclick="pressMenuRemote('102');">
+	<area shape="rect" coords=" 66, 50, 84, 61" title="Lan"             onclick="pressMenuRemote('376');">
+	<area shape="rect" coords=" 90, 50,108, 61" title="ZoomInOut"       onclick="pressMenuRemote('372');">
 
-	<area shape="rect" coords=" 17, 70, 36, 81" id ="107" title="end"             onclick="pressMenuRemote('107');">
-	<area shape="rect" coords=" 41, 70, 60, 81" id ="394" title="ytube"           onclick="pressMenuRemote('394');">
-	<area shape="rect" coords=" 66, 70, 84, 81" id ="362" title="openTimerList"   onclick="pressMenuRemote('362');">
-	<area shape="rect" coords=" 90, 70,108, 81" id ="392" title="audio"           onclick="pressMenuRemote('392');">
+	<area shape="rect" coords=" 17, 70, 36, 81" title="end"             onclick="pressMenuRemote('107');">
+	<area shape="rect" coords=" 41, 70, 60, 81" title="ytube"           onclick="pressMenuRemote('394');">
+	<area shape="rect" coords=" 66, 70, 84, 81" title="openTimerList"   onclick="pressMenuRemote('362');">
+	<area shape="rect" coords=" 90, 70,108, 81" title="audio"           onclick="pressMenuRemote('392');">
 
-	<area shape="rect" coords=" 17, 89, 36,101" id ="398" title="red"             onclick="pressMenuRemote('398');">
-	<area shape="rect" coords=" 41, 89, 60,101" id ="399" title="green"           onclick="pressMenuRemote('399');">
-	<area shape="rect" coords=" 66, 89, 84,101" id ="400" title="yellow"          onclick="pressMenuRemote('400');">
-	<area shape="rect" coords=" 90, 89,108,101" id ="401" title="blue"            onclick="pressMenuRemote('401');">
+	<area shape="rect" coords=" 17, 89, 36,101" title="red"             onclick="pressMenuRemote('398');">
+	<area shape="rect" coords=" 41, 89, 60,101" title="green"           onclick="pressMenuRemote('399');">
+	<area shape="rect" coords=" 66, 89, 84,101" title="yellow"          onclick="pressMenuRemote('400');">
+	<area shape="rect" coords=" 90, 89,108,101" title="blue"            onclick="pressMenuRemote('401');">
 
-	<area shape="rect" coords=" 17,109, 43,123" id ="2"   title="1"               onclick="pressMenuRemote('2');">
-	<area shape="rect" coords=" 50,109, 75,123" id ="3"   title="2"               onclick="pressMenuRemote('3');">
-	<area shape="rect" coords=" 83,109,108,123" id ="4"   title="3"               onclick="pressMenuRemote('4');">
-	<area shape="rect" coords=" 17,130, 43,144" id ="5"   title="4"               onclick="pressMenuRemote('5');">
-	<area shape="rect" coords=" 50,130, 75,144" id ="6"   title="5"               onclick="pressMenuRemote('6');">
-	<area shape="rect" coords=" 83,130,108,144" id ="7"   title="6"               onclick="pressMenuRemote('7');">
-	<area shape="rect" coords=" 17,150, 43,165" id ="8"   title="7"               onclick="pressMenuRemote('8');">
-	<area shape="rect" coords=" 50,150, 75,165" id ="9"   title="8"               onclick="pressMenuRemote('9');">
-	<area shape="rect" coords=" 83,150,108,165" id ="10"  title="9"               onclick="pressMenuRemote('10');">
-	<area shape="rect" coords=" 50,171, 75,185" id ="11"  title="0"               onclick="pressMenuRemote('11');">
-	<area shape="rect" coords=" 17,171, 43,185" id ="412" title="previous"        onclick="pressMenuRemote('412');">
-	<area shape="rect" coords=" 83,171,108,185" id ="407" title="next"            onclick="pressMenuRemote('407');">
+	<area shape="rect" coords=" 17,109, 43,123"   title="1"               onclick="pressMenuRemote('2');">
+	<area shape="rect" coords=" 50,109, 75,123"   title="2"               onclick="pressMenuRemote('3');">
+	<area shape="rect" coords=" 83,109,108,123"   title="3"               onclick="pressMenuRemote('4');">
+	<area shape="rect" coords=" 17,130, 43,144"   title="4"               onclick="pressMenuRemote('5');">
+	<area shape="rect" coords=" 50,130, 75,144"   title="5"               onclick="pressMenuRemote('6');">
+	<area shape="rect" coords=" 83,130,108,144"   title="6"               onclick="pressMenuRemote('7');">
+	<area shape="rect" coords=" 17,150, 43,165"   title="7"               onclick="pressMenuRemote('8');">
+	<area shape="rect" coords=" 50,150, 75,165"   title="8"               onclick="pressMenuRemote('9');">
+	<area shape="rect" coords=" 83,150,108,165"  title="9"               onclick="pressMenuRemote('10');">
+	<area shape="rect" coords=" 50,171, 75,185"  title="0"               onclick="pressMenuRemote('11');">
+	<area shape="rect" coords=" 17,171, 43,185" title="previous"        onclick="pressMenuRemote('412');">
+	<area shape="rect" coords=" 83,171,108,185" title="next"            onclick="pressMenuRemote('407');">
 
-	<area shape="rect" coords=" 22,194, 42,211" id ="115" title="volume up"       onclick="pressMenuRemote('115');">
-	<area shape="rect" coords=" 22,224, 43,239" id ="114" title="volume down"     onclick="pressMenuRemote('114');">
-	<area shape="rect" coords=" 82,194,104,211" id ="402" title="channelup"       onclick="pressMenuRemote('402');">
-	<area shape="rect" coords=" 82,224,104,239" id ="403" title="channeldown"     onclick="pressMenuRemote('403');">
-	<area shape="rect" coords=" 53,198, 72,210" id ="365" title="EPGPressed"      onclick="pressMenuRemote('365');">
-	<area shape="rect" coords=" 53,223, 72,235" id ="358" title="info"            onclick="pressMenuRemote('358');">
+	<area shape="rect" coords=" 22,194, 42,211" title="volume up"       onclick="pressMenuRemote('115');">
+	<area shape="rect" coords=" 22,224, 43,239" title="volume down"     onclick="pressMenuRemote('114');">
+	<area shape="rect" coords=" 82,194,104,211" title="channelup"       onclick="pressMenuRemote('402');">
+	<area shape="rect" coords=" 82,224,104,239" title="channeldown"     onclick="pressMenuRemote('403');">
+	<area shape="rect" coords=" 53,198, 72,210" title="EPGPressed"      onclick="pressMenuRemote('365');">
+	<area shape="rect" coords=" 53,223, 72,235" title="info"            onclick="pressMenuRemote('358');">
 
-	<area shape="rect" coords=" 25,254, 39,268" id ="139" title="menu"            onclick="pressMenuRemote('139');">
-	<area shape="rect" coords=" 87,254,100,268" id ="174" title="exit"            onclick="pressMenuRemote('174');">
+	<area shape="rect" coords=" 25,254, 39,268" title="menu"            onclick="pressMenuRemote('139');">
+	<area shape="rect" coords=" 87,254,100,268" title="exit"            onclick="pressMenuRemote('174');">
 
-	<area shape="rect" coords=" 51,255, 76,271" id ="103" title="up"              onclick="pressMenuRemote('103');">
-	<area shape="rect" coords=" 51,307, 76,323" id ="108" title="down"            onclick="pressMenuRemote('108');">
-	<area shape="rect" coords=" 22,279, 42,300" id ="105" title="left"            onclick="pressMenuRemote('105');">
-	<area shape="rect" coords=" 85,279,104,300" id ="106" title="right"           onclick="pressMenuRemote('106');">
-	<area shape="rect" coords=" 49,278, 77,300" id ="352" title="OK"              onclick="pressMenuRemote('352');">
+	<area shape="rect" coords=" 51,255, 76,271" title="up"              onclick="pressMenuRemote('103');">
+	<area shape="rect" coords=" 51,307, 76,323" title="down"            onclick="pressMenuRemote('108');">
+	<area shape="rect" coords=" 22,279, 42,300" title="left"            onclick="pressMenuRemote('105');">
+	<area shape="rect" coords=" 85,279,104,300" title="right"           onclick="pressMenuRemote('106');">
+	<area shape="rect" coords=" 49,278, 77,300" title="OK"              onclick="pressMenuRemote('352');">
 
-	<area shape="rect" coords=" 25,309, 39,323" id ="381" title="openSatellites"  onclick="pressMenuRemote('381');">
-	<area shape="rect" coords=" 87,309,100,323" id ="406" title="prov"            onclick="pressMenuRemote('406');">
+	<area shape="rect" coords=" 25,309, 39,323" title="openSatellites"  onclick="pressMenuRemote('381');">
+	<area shape="rect" coords=" 87,309,100,323" title="prov"            onclick="pressMenuRemote('406');">
 
-	<area shape="rect" coords=" 17,338, 36,351" id ="393" title="showMovies"      onclick="pressMenuRemote('393');">
-	<area shape="rect" coords=" 41,338, 60,351" id ="395" title="showMediaPlayer" onclick="pressMenuRemote('395');">
-	<area shape="rect" coords=" 65,338, 84,351" id ="388" title="startTeletext"   onclick="pressMenuRemote('388');">
-	<area shape="rect" coords=" 90,338,108,351" id ="370" title="subtitle"        onclick="pressMenuRemote('370');">
+	<area shape="rect" coords=" 17,338, 36,351" title="showMovies"      onclick="pressMenuRemote('393');">
+	<area shape="rect" coords=" 41,338, 60,351" title="showMediaPlayer" onclick="pressMenuRemote('395');">
+	<area shape="rect" coords=" 65,338, 84,351" title="startTeletext"   onclick="pressMenuRemote('388');">
+	<area shape="rect" coords=" 90,338,108,351" title="subtitle"        onclick="pressMenuRemote('370');">
 
-	<area shape="rect" coords=" 17,357, 36,370" id ="168" title="rewind"          onclick="pressMenuRemote('168');">
-	<area shape="rect" coords=" 41,357, 60,370" id ="207" title="play"            onclick="pressMenuRemote('207');">
-	<area shape="rect" coords=" 65,357, 84,370" id ="119" title="pause"           onclick="pressMenuRemote('119');">
-	<area shape="rect" coords=" 65,357, 84,370" id ="164" title="timeshiftStart"  onclick="pressMenuRemote('164');">
-	<area shape="rect" coords=" 90,357,108,370" id ="208" title="forward"         onclick="pressMenuRemote('208');">
+	<area shape="rect" coords=" 17,357, 36,370" title="rewind"          onclick="pressMenuRemote('168');">
+	<area shape="rect" coords=" 41,357, 60,370" title="play"            onclick="pressMenuRemote('207');">
+	<area shape="rect" coords=" 65,357, 84,370" title="pause"           onclick="pressMenuRemote('119');">
+	<area shape="rect" coords=" 65,357, 84,370" title="timeshiftStart"  onclick="pressMenuRemote('164');">
+	<area shape="rect" coords=" 90,357,108,370" title="forward"         onclick="pressMenuRemote('208');">
 
-	<area shape="rect" coords=" 17,377, 36,390" id ="377" title="tv"              onclick="pressMenuRemote('377');">
-	<area shape="rect" coords=" 41,377, 60,390" id ="167" title="record"          onclick="pressMenuRemote('167');">
-	<area shape="rect" coords=" 65,377, 84,390" id ="128" title="timeshiftStop"   onclick="pressMenuRemote('128');">
-	<area shape="rect" coords=" 90,377,108,390" id ="385" title="radio"           onclick="pressMenuRemote('385');">
+	<area shape="rect" coords=" 17,377, 36,390" title="tv"              onclick="pressMenuRemote('377');">
+	<area shape="rect" coords=" 41,377, 60,390" title="record"          onclick="pressMenuRemote('167');">
+	<area shape="rect" coords=" 65,377, 84,390" title="timeshiftStop"   onclick="pressMenuRemote('128');">
+	<area shape="rect" coords=" 90,377,108,390" title="radio"           onclick="pressMenuRemote('385');">
 
- 	<area shape="rect" coords=" 17,397, 36,409" id =" 59" title="f1"              onclick="pressMenuRemote('59');">
-	<area shape="rect" coords=" 41,397, 60,409" id =" 60" title="f2"              onclick="pressMenuRemote('60');">
-	<area shape="rect" coords=" 65,397, 84,409" id =" 61" title="f3"              onclick="pressMenuRemote('61');">
-	<area shape="rect" coords=" 90,397,108,409" id =" 62" title="f4"              onclick="pressMenuRemote('62');">
+ 	<area shape="rect" coords=" 17,397, 36,409" title="f1"              onclick="pressMenuRemote('59');">
+	<area shape="rect" coords=" 41,397, 60,409" title="f2"              onclick="pressMenuRemote('60');">
+	<area shape="rect" coords=" 65,397, 84,409" title="f3"              onclick="pressMenuRemote('61');">
+	<area shape="rect" coords=" 90,397,108,409" title="f4"              onclick="pressMenuRemote('62');">
 
 
 </map>

--- a/BoxBranding/remotes/revo/remote.html
+++ b/BoxBranding/remotes/revo/remote.html
@@ -1,66 +1,66 @@
 <img border='0' src='/static/remotes/revo/rc.png' usemap='#map' >
 <map name="map">
 	<!-- brand: technomate, model : tmtwin4k rcu with universal functionality -->
-	<area shape="circle" coords="41,35,11" id ="116" title="Power" onclick="pressMenuRemote('116');">	
-	<area shape="circle" coords="97,35,7" id ="113" title="mute" onclick="pressMenuRemote('113');">
+	<area shape="circle" coords="41,35,11" title="Power" onclick="pressMenuRemote('116');">	
+	<area shape="circle" coords="97,35,7" title="mute" onclick="pressMenuRemote('113');">
 		
-	<area shape="rect" coords="30,53,52,67" id ="138" title="help" onclick="pressMenuRemote('138');">	
-	<area shape="rect" coords="58,53,79,67" id ="102" title="home" onclick="pressMenuRemote('102');">	
-	<area shape="rect" coords="85,53,107,67" id ="107" title="end" onclick="pressMenuRemote('107');">
+	<area shape="rect" coords="30,53,52,67" title="help" onclick="pressMenuRemote('138');">	
+	<area shape="rect" coords="58,53,79,67" title="home" onclick="pressMenuRemote('102');">	
+	<area shape="rect" coords="85,53,107,67" title="end" onclick="pressMenuRemote('107');">
 
-	<area shape="rect" coords="30,72,51,85" id ="375" title="pip" onclick="pressMenuRemote('375');">
-	<area shape="rect" coords="58,72,79,85" id ="395" title="showMediaPlayer" onclick="pressMenuRemote('395');">
-	<area shape="rect" coords="85,72,107,85" id ="376" title="Lan" onclick="pressMenuRemote('376');">
+	<area shape="rect" coords="30,72,51,85" title="pip" onclick="pressMenuRemote('375');">
+	<area shape="rect" coords="58,72,79,85" title="showMediaPlayer" onclick="pressMenuRemote('395');">
+	<area shape="rect" coords="85,72,107,85" title="Lan" onclick="pressMenuRemote('376');">
 	
-	<area shape="rect" coords="31,93,49,107" id ="2" title="1" onclick="pressMenuRemote('2');">
-	<area shape="rect" coords="56,93,79,107" id ="3" title="2" onclick="pressMenuRemote('3');">	
-	<area shape="rect" coords="86,93,108,107" id ="4" title="3" onclick="pressMenuRemote('4');">
-	<area shape="rect" coords="31,117,49,130" id ="5" title="4" onclick="pressMenuRemote('5');">
-	<area shape="rect" coords="56,117,79,130" id ="6" title="5" onclick="pressMenuRemote('6');">
-	<area shape="rect" coords="86,117,108,130" id ="7" title="6" onclick="pressMenuRemote('7');">
-	<area shape="rect" coords="31,138,49,154" id ="8" title="7" onclick="pressMenuRemote('8');">
-	<area shape="rect" coords="56,138,79,154" id ="9" title="8" onclick="pressMenuRemote('9');">
-	<area shape="rect" coords="86,138,108,154" id ="10" title="9" onclick="pressMenuRemote('10');">
-	<area shape="rect" coords="31,160,49,175" id ="412" title="previous" onclick="pressMenuRemote('412');">
-	<area shape="rect" coords="56,160,79,175" id ="11" title="0" onclick="pressMenuRemote('11');">
-	<area shape="rect" coords="86,160,108,175" id ="407" title="next" onclick="pressMenuRemote('407');">
+	<area shape="rect" coords="31,93,49,107" title="1" onclick="pressMenuRemote('2');">
+	<area shape="rect" coords="56,93,79,107" title="2" onclick="pressMenuRemote('3');">	
+	<area shape="rect" coords="86,93,108,107" title="3" onclick="pressMenuRemote('4');">
+	<area shape="rect" coords="31,117,49,130" title="4" onclick="pressMenuRemote('5');">
+	<area shape="rect" coords="56,117,79,130" title="5" onclick="pressMenuRemote('6');">
+	<area shape="rect" coords="86,117,108,130" title="6" onclick="pressMenuRemote('7');">
+	<area shape="rect" coords="31,138,49,154" title="7" onclick="pressMenuRemote('8');">
+	<area shape="rect" coords="56,138,79,154" title="8" onclick="pressMenuRemote('9');">
+	<area shape="rect" coords="86,138,108,154" title="9" onclick="pressMenuRemote('10');">
+	<area shape="rect" coords="31,160,49,175" title="previous" onclick="pressMenuRemote('412');">
+	<area shape="rect" coords="56,160,79,175" title="0" onclick="pressMenuRemote('11');">
+	<area shape="rect" coords="86,160,108,175" title="next" onclick="pressMenuRemote('407');">
 
-	<area shape="circle" coords="39,197,13" id ="115" title="volume up" onclick="pressMenuRemote('115');">
-	<area shape="circle" coords="39,227,13" id ="114" title="volume down" onclick="pressMenuRemote('114');">
-	<area shape="circle" coords="99,197,13" id ="402" title="channelup" onclick="pressMenuRemote('402');">
-	<area shape="circle" coords="99,227,13" id ="403" title="channeldown" onclick="pressMenuRemote('403');">
-	<area shape="circle" coords="68,197,7" id ="365" title="EPGPressed" onclick="pressMenuRemote('365');">
-	<area shape="circle" coords="68,227,7" id ="358" title="info" onclick="pressMenuRemote('358');">
+	<area shape="circle" coords="39,197,13" title="volume up" onclick="pressMenuRemote('115');">
+	<area shape="circle" coords="39,227,13" title="volume down" onclick="pressMenuRemote('114');">
+	<area shape="circle" coords="99,197,13" title="channelup" onclick="pressMenuRemote('402');">
+	<area shape="circle" coords="99,227,13" title="channeldown" onclick="pressMenuRemote('403');">
+	<area shape="circle" coords="68,197,7" title="EPGPressed" onclick="pressMenuRemote('365');">
+	<area shape="circle" coords="68,227,7" title="info" onclick="pressMenuRemote('358');">
 
-	<area shape="rect" coords="26,250,43,260" id ="392" title="audio" onclick="pressMenuRemote('392');">
-	<area shape="rect" coords="48,250,64,260" id ="388" title="startTeletext" onclick="pressMenuRemote('388');">
-	<area shape="rect" coords="72,250,87,260" id ="370" title="subtitle" onclick="pressMenuRemote('370');">
-	<area shape="rect" coords="94,250,108,260" id ="362" title="openTimerList" onclick="pressMenuRemote('362');">
+	<area shape="rect" coords="26,250,43,260" title="audio" onclick="pressMenuRemote('392');">
+	<area shape="rect" coords="48,250,64,260" title="startTeletext" onclick="pressMenuRemote('388');">
+	<area shape="rect" coords="72,250,87,260" title="subtitle" onclick="pressMenuRemote('370');">
+	<area shape="rect" coords="94,250,108,260" title="openTimerList" onclick="pressMenuRemote('362');">
 
-	<area shape="circle" coords="32,276,7" id ="139" title="menu" onclick="pressMenuRemote('139');">
-	<area shape="circle" coords="105,276,7" id ="174" title="exit" onclick="pressMenuRemote('174');">
-	<area shape="circle" coords="32,344,7" id ="381" title="openSatellites" onclick="pressMenuRemote('381');">
-	<area shape="circle" coords="105,344,7" id ="393" title="showMovies" onclick="pressMenuRemote('393');">
+	<area shape="circle" coords="32,276,7" title="menu" onclick="pressMenuRemote('139');">
+	<area shape="circle" coords="105,276,7" title="exit" onclick="pressMenuRemote('174');">
+	<area shape="circle" coords="32,344,7" title="openSatellites" onclick="pressMenuRemote('381');">
+	<area shape="circle" coords="105,344,7" title="showMovies" onclick="pressMenuRemote('393');">
 
-	<area shape="rect" coords="55,277,85,291" id ="103" title="up" onclick="pressMenuRemote('103');">
-	<area shape="rect" coords="55,329,85,344" id ="108" title="down" onclick="pressMenuRemote('108');">
-	<area shape="rect" coords="36,296,52,326" id ="105" title="left" onclick="pressMenuRemote('105');">
-	<area shape="rect" coords="87,296,102,326" id ="106" title="right" onclick="pressMenuRemote('106');">
-	<area shape="circle" coords="69,311,14" id ="352" title="OK" onclick="pressMenuRemote('352');">
+	<area shape="rect" coords="55,277,85,291" title="up" onclick="pressMenuRemote('103');">
+	<area shape="rect" coords="55,329,85,344" title="down" onclick="pressMenuRemote('108');">
+	<area shape="rect" coords="36,296,52,326" title="left" onclick="pressMenuRemote('105');">
+	<area shape="rect" coords="87,296,102,326" title="right" onclick="pressMenuRemote('106');">
+	<area shape="circle" coords="69,311,14" title="OK" onclick="pressMenuRemote('352');">
 
-	<area shape="rect" coords="26,359,45,372" id ="398" title="red" onclick="pressMenuRemote('398');">
-	<area shape="rect" coords="47,359,67,372" id ="399" title="green" onclick="pressMenuRemote('399');">
-	<area shape="rect" coords="70,359,89,372" id ="400" title="yellow" onclick="pressMenuRemote('400');">
-	<area shape="rect" coords="93,359,111,372" id ="401" title="blue" onclick="pressMenuRemote('401');">
+	<area shape="rect" coords="26,359,45,372" title="red" onclick="pressMenuRemote('398');">
+	<area shape="rect" coords="47,359,67,372" title="green" onclick="pressMenuRemote('399');">
+	<area shape="rect" coords="70,359,89,372" title="yellow" onclick="pressMenuRemote('400');">
+	<area shape="rect" coords="93,359,111,372" title="blue" onclick="pressMenuRemote('401');">
 
-	<area shape="rect" coords="26,383,45,396" id ="168" title="rewind" onclick="pressMenuRemote('168');">
-	<area shape="rect" coords="47,383,67,396" id ="207" title="play" onclick="pressMenuRemote('207');">
-	<area shape="rect" coords="70,383,89,396" id ="119" title="pause" onclick="pressMenuRemote('119');">
-	<area shape="rect" coords="70,383,89,396" id ="164" title="timeshiftStart" onclick="pressMenuRemote('164');">
-	<area shape="rect" coords="93,383,111,396" id ="208" title="forward" onclick="pressMenuRemote('208');">
+	<area shape="rect" coords="26,383,45,396" title="rewind" onclick="pressMenuRemote('168');">
+	<area shape="rect" coords="47,383,67,396" title="play" onclick="pressMenuRemote('207');">
+	<area shape="rect" coords="70,383,89,396" title="pause" onclick="pressMenuRemote('119');">
+	<area shape="rect" coords="70,383,89,396" title="timeshiftStart" onclick="pressMenuRemote('164');">
+	<area shape="rect" coords="93,383,111,396" title="forward" onclick="pressMenuRemote('208');">
 
-	<area shape="rect" coords="26,402,45,413" id ="377" title="tv" onclick="pressMenuRemote('377');">
-	<area shape="rect" coords="47,402,67,413" id ="167" title="record" onclick="pressMenuRemote('167');">
-	<area shape="rect" coords="70,402,89,413" id ="128" title="timeshiftStop" onclick="pressMenuRemote('128');">	
-	<area shape="rect" coords="93,402,111,413" id ="385" title="radio" onclick="pressMenuRemote('385');">
+	<area shape="rect" coords="26,402,45,413" title="tv" onclick="pressMenuRemote('377');">
+	<area shape="rect" coords="47,402,67,413" title="record" onclick="pressMenuRemote('167');">
+	<area shape="rect" coords="70,402,89,413" title="timeshiftStop" onclick="pressMenuRemote('128');">	
+	<area shape="rect" coords="93,402,111,413" title="radio" onclick="pressMenuRemote('385');">
 </map>

--- a/BoxBranding/remotes/tm1/remote.html
+++ b/BoxBranding/remotes/tm1/remote.html
@@ -1,40 +1,40 @@
 <img border='0' src='/static/remotes/tm1/rc.png' usemap='#map' >
 <map name="map">
 	<area shape="rect" coords="98,62,118,72" title="mute" onclick="pressMenuRemote('113');">
-	<area shape="rect" coords="105,28,15" id ="116" title="Power" onclick="pressMenuRemote('116');">
-	<area shape="rect" coords="33,53,15" id ="388" title="text" onclick="pressMenuRemote('388');">
-	<area shape="rect" coords="58,53,15" id ="370" title="subtitle" onclick="pressMenuRemote('370');">
-	<area shape="rect" coords="82,53,15" id ="102" title="home" onclick="pressMenuRemote('102');">
-	<area shape="rect" coords="105,53,15" id ="107" title="end" onclick="pressMenuRemote('107');">
+	<area shape="rect" coords="105,28,15" title="Power" onclick="pressMenuRemote('116');">
+	<area shape="rect" coords="33,53,15" title="text" onclick="pressMenuRemote('388');">
+	<area shape="rect" coords="58,53,15" title="subtitle" onclick="pressMenuRemote('370');">
+	<area shape="rect" coords="82,53,15" title="home" onclick="pressMenuRemote('102');">
+	<area shape="rect" coords="105,53,15" title="end" onclick="pressMenuRemote('107');">
 
-	<area shape="rect" coords="20,62,40,72" id ="2" title="1" onclick="pressMenuRemote('2');">
-	<area shape="rect" coords="46,62,66,72" id ="3" title="2" onclick="pressMenuRemote('3');">
-	<area shape="rect" coords="72,62,92,72" id ="4" title="3" onclick="pressMenuRemote('4');">
-	<area shape="rect" coords="20,78,40,88" id ="5" title="4" onclick="pressMenuRemote('5');">
-	<area shape="rect" coords="46,78,66,88" id ="6" title="5" onclick="pressMenuRemote('6');">
-	<area shape="rect" coords="72,78,92,88" id ="7" title="6" onclick="pressMenuRemote('7');">
-	<area shape="rect" coords="20,96,40,106" id ="8" title="7" onclick="pressMenuRemote('8');">
-	<area shape="rect" coords="46,96,66,106" id ="9" title="8" onclick="pressMenuRemote('9');">
-	<area shape="rect" coords="72,62,92,106" id ="10" title="9" onclick="pressMenuRemote('10');">
-	<area shape="rect" coords="46,112,66,125" id ="11" title="0" onclick="pressMenuRemote('11');">
+	<area shape="rect" coords="20,62,40,72" title="1" onclick="pressMenuRemote('2');">
+	<area shape="rect" coords="46,62,66,72" title="2" onclick="pressMenuRemote('3');">
+	<area shape="rect" coords="72,62,92,72" title="3" onclick="pressMenuRemote('4');">
+	<area shape="rect" coords="20,78,40,88" title="4" onclick="pressMenuRemote('5');">
+	<area shape="rect" coords="46,78,66,88" title="5" onclick="pressMenuRemote('6');">
+	<area shape="rect" coords="72,78,92,88" title="6" onclick="pressMenuRemote('7');">
+	<area shape="rect" coords="20,96,40,106" title="7" onclick="pressMenuRemote('8');">
+	<area shape="rect" coords="46,96,66,106" title="8" onclick="pressMenuRemote('9');">
+	<area shape="rect" coords="72,62,92,106" title="9" onclick="pressMenuRemote('10');">
+	<area shape="rect" coords="46,112,66,125" title="0" onclick="pressMenuRemote('11');">
 
 	<!-- Added Key -->
 	<area shape="rect" coords="96,95,118,107" title="Lan" onclick="pressMenuRemote('376');">
-	<area shape="circle" coords="104,214,18" id ="174" title="exit" onclick="pressMenuRemote('174');">
+	<area shape="circle" coords="104,214,18" title="exit" onclick="pressMenuRemote('174');">
 
-	<area shape="rect" coords="94,134,117,154" id ="402" title="channelup" onclick="pressMenuRemote('402');">
-	<area shape="rect" coords="94,174,117,194" id ="403" title="channeldown" onclick="pressMenuRemote('403');">
+	<area shape="rect" coords="94,134,117,154" title="channelup" onclick="pressMenuRemote('402');">
+	<area shape="rect" coords="94,174,117,194" title="channeldown" onclick="pressMenuRemote('403');">
 
-	<area shape="rect" coords="20,134,40,154" id ="115" title="volume up" onclick="pressMenuRemote('115');">
-	<area shape="rect" coords="20,174,40,194" id ="114" title="volume down" onclick="pressMenuRemote('114');">
+	<area shape="rect" coords="20,134,40,154" title="volume up" onclick="pressMenuRemote('115');">
+	<area shape="rect" coords="20,174,40,194" title="volume down" onclick="pressMenuRemote('114');">
 
-	<area shape="rect" coords="20,112,40,125" id ="412" title="previous" onclick="pressMenuRemote('412');">
-	<area shape="rect" coords="72,112,92,125" id ="407" title="next" onclick="pressMenuRemote('407');">
+	<area shape="rect" coords="20,112,40,125" title="previous" onclick="pressMenuRemote('412');">
+	<area shape="rect" coords="72,112,92,125" title="next" onclick="pressMenuRemote('407');">
 
-	<area shape="rect" coords="20,323,41,332" id ="398" title="red" onclick="pressMenuRemote('398');">
-	<area shape="rect" coords="45,323,66,332" id ="399" title="green" onclick="pressMenuRemote('399');">
-	<area shape="rect" coords="70,323,91,332" id ="400" title="yellow" onclick="pressMenuRemote('400');">
-	<area shape="rect" coords="95,323,116,332" id ="401" title="blue" onclick="pressMenuRemote('401');">
+	<area shape="rect" coords="20,323,41,332" title="red" onclick="pressMenuRemote('398');">
+	<area shape="rect" coords="45,323,66,332" title="green" onclick="pressMenuRemote('399');">
+	<area shape="rect" coords="70,323,91,332" title="yellow" onclick="pressMenuRemote('400');">
+	<area shape="rect" coords="95,323,116,332" title="blue" onclick="pressMenuRemote('401');">
 
 	<area shape="circle" coords="69,145,15" title="EPGPressed" onclick="pressMenuRemote(365);">
 	<area shape="circle" coords="33,280,20" title="openSatellites" onclick="pressMenuRemote(381);">
@@ -67,76 +67,76 @@
 	<!-- Rf modulator -->
 	<area shape="rect" coords="98,114,116,124" title="showRFmod" onclick="pressMenuRemote('371');">
 
-	<area shape="circle" coords="70,213,15" id ="103" title="up" onclick="pressMenuRemote('103');">
-	<area shape="circle" coords="70,283,15" id ="108" title="down" onclick="pressMenuRemote('108');">
-	<area shape="circle" coords="35,248,15" id ="105" title="left" onclick="pressMenuRemote('105');">
-	<area shape="circle" coords="105,248,15" id ="106" title="right" onclick="pressMenuRemote('106');">
+	<area shape="circle" coords="70,213,15" title="up" onclick="pressMenuRemote('103');">
+	<area shape="circle" coords="70,283,15" title="down" onclick="pressMenuRemote('108');">
+	<area shape="circle" coords="35,248,15" title="left" onclick="pressMenuRemote('105');">
+	<area shape="circle" coords="105,248,15" title="right" onclick="pressMenuRemote('106');">
 
-	<area shape="circle" coords="70,248,20" id ="352" title="OK" onclick="pressMenuRemote('352');">
-	<area shape="circle" coords="69,180,15" id ="392" title="audio" onclick="pressMenuRemote('392');">
+	<area shape="circle" coords="70,248,20" title="OK" onclick="pressMenuRemote('352');">
+	<area shape="circle" coords="69,180,15" title="audio" onclick="pressMenuRemote('392');">
 
-	<area shape="circle" coords="32,214,18" id ="139" title="menu" onclick="pressMenuRemote('139');">
-	<area shape="rect" coords="55,342,82,358" id ="167" title="record" onclick="pressMenuRemote('167');">
-	<area shape="rect" coords="20,342,46,357" id ="393" title="videoaltlast" onclick="pressMenuRemote('393');">
+	<area shape="circle" coords="32,214,18" title="menu" onclick="pressMenuRemote('139');">
+	<area shape="rect" coords="55,342,82,358" title="record" onclick="pressMenuRemote('167');">
+	<area shape="rect" coords="20,342,46,357" title="videoaltlast" onclick="pressMenuRemote('393');">
 
-	<area shape="rect" coords="98,78,118,88" id ="138" title="help" onclick="pressMenuRemote('138');">
+	<area shape="rect" coords="98,78,118,88" title="help" onclick="pressMenuRemote('138');">
 
-	<area shape="circle" coords="36,383,15" id ="168" title="rewind" onclick="pressMenuRemote('168');">
-	<area shape="circle" coords="59,383,15" id ="207" title="play" onclick="pressMenuRemote('207');">
-	<area shape="circle" coords="81,383,15" id ="119" title="pause" onclick="pressMenuRemote('119');">
-	<area shape="circle" coords="104,383,15" id ="208" title="forward" onclick="pressMenuRemote('208');">
-	<area shape="circle" coords="36,405,15" id ="377" title="tv" onclick="pressMenuRemote('377');">
+	<area shape="circle" coords="36,383,15" title="rewind" onclick="pressMenuRemote('168');">
+	<area shape="circle" coords="59,383,15" title="play" onclick="pressMenuRemote('207');">
+	<area shape="circle" coords="81,383,15" title="pause" onclick="pressMenuRemote('119');">
+	<area shape="circle" coords="104,383,15" title="forward" onclick="pressMenuRemote('208');">
+	<area shape="circle" coords="36,405,15" title="tv" onclick="pressMenuRemote('377');">
 
 
-	<area shape="circle" coords="81,405,15" id ="128" title="stop" onclick="pressMenuRemote('128');">
-	<area shape="circle" coords="104,405,15" id ="385" title="radio" onclick="pressMenuRemote('385');">
+	<area shape="circle" coords="81,405,15" title="stop" onclick="pressMenuRemote('128');">
+	<area shape="circle" coords="104,405,15" title="radio" onclick="pressMenuRemote('385');">
 
-	<area shape="circle" coords="105,279,12" id ="358" title="Info" onclick="pressMenuRemote('358');">
+	<area shape="circle" coords="105,279,12" title="Info" onclick="pressMenuRemote('358');">
 </map>
 <!--
 	<area shape="circle" coords="33,28,15" title="mute" onclick="pressMenuRemote('113');">
-	<area shape="circle" coords="105,28,15" id ="116" title="Power" onclick="pressMenuRemote('116');">
-	<area shape="circle" coords="33,53,15" id ="388" title="text" onclick="pressMenuRemote('388');">
-	<area shape="circle" coords="58,53,15" id ="370" title="subtitle" onclick="pressMenuRemote('370');">
-	<area shape="circle" coords="82,53,15" id ="102" title="home" onclick="pressMenuRemote('102');">
-	<area shape="circle" coords="105,53,15" id ="107" title="end" onclick="pressMenuRemote('107');">
-	<area shape="circle" coords="38,79,15" id ="2" title="1" onclick="pressMenuRemote('2');">
-	<area shape="circle" coords="70,79,15" id ="3" title="2" onclick="pressMenuRemote('3');">
-	<area shape="circle" coords="102,79,15" id ="4" title="3" onclick="pressMenuRemote('4');">
-	<area shape="circle" coords="38,106,15" id ="5" title="4" onclick="pressMenuRemote('5');">
-	<area shape="circle" coords="70,106,15" id ="6" title="5" onclick="pressMenuRemote('6');">
-	<area shape="circle" coords="102,106,15" id ="7" title="6" onclick="pressMenuRemote('7');">
-	<area shape="circle" coords="38,133,15" id ="8" title="7" onclick="pressMenuRemote('8');">
-	<area shape="circle" coords="70,133,15" id ="9" title="8" onclick="pressMenuRemote('9');">
-	<area shape="circle" coords="102,133,15" id ="10" title="9" onclick="pressMenuRemote('10');">
-	<area shape="circle" coords="38,161,15" id ="412" title="previous" onclick="pressMenuRemote('412');">
-	<area shape="circle" coords="70,161,15" id ="11" title="0" onclick="pressMenuRemote('11');">
-	<area shape="circle" coords="102,161,15" id ="407" title="next" onclick="pressMenuRemote('407');">
-	<area shape="circle" coords="33,186,15" id ="398" title="red" onclick="pressMenuRemote('398');">
-	<area shape="circle" coords="58,186,15" id ="399" title="green" onclick="pressMenuRemote('399');">
-	<area shape="circle" coords="82,186,15" id ="400" title="yellow" onclick="pressMenuRemote('400');">
-	<area shape="circle" coords="105,186,15" id ="401" title="blue" onclick="pressMenuRemote('401');">
-	<area shape="circle" coords="70,213,15" id ="103" title="up" onclick="pressMenuRemote('103');">
-	<area shape="circle" coords="70,283,15" id ="108" title="down" onclick="pressMenuRemote('108');">
-	<area shape="circle" coords="35,248,15" id ="105" title="left" onclick="pressMenuRemote('105');">
-	<area shape="circle" coords="105,248,15" id ="106" title="right" onclick="pressMenuRemote('106');">
-	<area shape="circle" coords="70,248,20" id ="352" title="OK" onclick="pressMenuRemote('352');">
-	<area shape="circle" coords="40,307,15" id ="115" title="volume up" onclick="pressMenuRemote('115');">
-	<area shape="circle" coords="40,338,13" id ="114" title="volume down" onclick="pressMenuRemote('114');">
-	<area shape="circle" coords="70,310,15" id ="174" title="exit" onclick="pressMenuRemote('174');">
-	<area shape="circle" coords="70,334,15" id ="358" title="epg" onclick="pressMenuRemote('358');">
-	<area shape="circle" coords="99,307,15" id ="402" title="channelup" onclick="pressMenuRemote('402');">
-	<area shape="circle" coords="99,338,15" id ="403" title="channeldown" onclick="pressMenuRemote('403');">
-	<area shape="circle" coords="36,362,15" id ="139" title="menu" onclick="pressMenuRemote('139');">
-	<area shape="circle" coords="59,362,15" id ="393" title="videoaltlast" onclick="pressMenuRemote('393');">
-	<area shape="circle" coords="81,362,15" id ="392" title="audio" onclick="pressMenuRemote('392');">
-	<area shape="circle" coords="104,362,15" id ="138" title="help" onclick="pressMenuRemote('138');">
-	<area shape="circle" coords="36,383,15" id ="168" title="rewind" onclick="pressMenuRemote('168');">
-	<area shape="circle" coords="59,383,15" id ="207" title="play" onclick="pressMenuRemote('207');">
-	<area shape="circle" coords="81,383,15" id ="119" title="pause" onclick="pressMenuRemote('119');">
-	<area shape="circle" coords="104,383,15" id ="208" title="forward" onclick="pressMenuRemote('208');">
-	<area shape="circle" coords="36,405,15" id ="377" title="tv" onclick="pressMenuRemote('377');">
-	<area shape="circle" coords="59,405,15" id ="167" title="record" onclick="pressMenuRemote('167');">
-	<area shape="circle" coords="81,405,15" id ="128" title="stop" onclick="pressMenuRemote('128');">
-	<area shape="circle" coords="104,405,15" id ="385" title="radio" onclick="pressMenuRemote('385');">
+	<area shape="circle" coords="105,28,15" title="Power" onclick="pressMenuRemote('116');">
+	<area shape="circle" coords="33,53,15" title="text" onclick="pressMenuRemote('388');">
+	<area shape="circle" coords="58,53,15" title="subtitle" onclick="pressMenuRemote('370');">
+	<area shape="circle" coords="82,53,15" title="home" onclick="pressMenuRemote('102');">
+	<area shape="circle" coords="105,53,15" title="end" onclick="pressMenuRemote('107');">
+	<area shape="circle" coords="38,79,15" title="1" onclick="pressMenuRemote('2');">
+	<area shape="circle" coords="70,79,15" title="2" onclick="pressMenuRemote('3');">
+	<area shape="circle" coords="102,79,15" title="3" onclick="pressMenuRemote('4');">
+	<area shape="circle" coords="38,106,15" title="4" onclick="pressMenuRemote('5');">
+	<area shape="circle" coords="70,106,15" title="5" onclick="pressMenuRemote('6');">
+	<area shape="circle" coords="102,106,15" title="6" onclick="pressMenuRemote('7');">
+	<area shape="circle" coords="38,133,15" title="7" onclick="pressMenuRemote('8');">
+	<area shape="circle" coords="70,133,15" title="8" onclick="pressMenuRemote('9');">
+	<area shape="circle" coords="102,133,15" title="9" onclick="pressMenuRemote('10');">
+	<area shape="circle" coords="38,161,15" title="previous" onclick="pressMenuRemote('412');">
+	<area shape="circle" coords="70,161,15" title="0" onclick="pressMenuRemote('11');">
+	<area shape="circle" coords="102,161,15" title="next" onclick="pressMenuRemote('407');">
+	<area shape="circle" coords="33,186,15" title="red" onclick="pressMenuRemote('398');">
+	<area shape="circle" coords="58,186,15" title="green" onclick="pressMenuRemote('399');">
+	<area shape="circle" coords="82,186,15" title="yellow" onclick="pressMenuRemote('400');">
+	<area shape="circle" coords="105,186,15" title="blue" onclick="pressMenuRemote('401');">
+	<area shape="circle" coords="70,213,15" title="up" onclick="pressMenuRemote('103');">
+	<area shape="circle" coords="70,283,15" title="down" onclick="pressMenuRemote('108');">
+	<area shape="circle" coords="35,248,15" title="left" onclick="pressMenuRemote('105');">
+	<area shape="circle" coords="105,248,15" title="right" onclick="pressMenuRemote('106');">
+	<area shape="circle" coords="70,248,20" title="OK" onclick="pressMenuRemote('352');">
+	<area shape="circle" coords="40,307,15" title="volume up" onclick="pressMenuRemote('115');">
+	<area shape="circle" coords="40,338,13" title="volume down" onclick="pressMenuRemote('114');">
+	<area shape="circle" coords="70,310,15" title="exit" onclick="pressMenuRemote('174');">
+	<area shape="circle" coords="70,334,15" title="epg" onclick="pressMenuRemote('358');">
+	<area shape="circle" coords="99,307,15" title="channelup" onclick="pressMenuRemote('402');">
+	<area shape="circle" coords="99,338,15" title="channeldown" onclick="pressMenuRemote('403');">
+	<area shape="circle" coords="36,362,15" title="menu" onclick="pressMenuRemote('139');">
+	<area shape="circle" coords="59,362,15" title="videoaltlast" onclick="pressMenuRemote('393');">
+	<area shape="circle" coords="81,362,15" title="audio" onclick="pressMenuRemote('392');">
+	<area shape="circle" coords="104,362,15" title="help" onclick="pressMenuRemote('138');">
+	<area shape="circle" coords="36,383,15" title="rewind" onclick="pressMenuRemote('168');">
+	<area shape="circle" coords="59,383,15" title="play" onclick="pressMenuRemote('207');">
+	<area shape="circle" coords="81,383,15" title="pause" onclick="pressMenuRemote('119');">
+	<area shape="circle" coords="104,383,15" title="forward" onclick="pressMenuRemote('208');">
+	<area shape="circle" coords="36,405,15" title="tv" onclick="pressMenuRemote('377');">
+	<area shape="circle" coords="59,405,15" title="record" onclick="pressMenuRemote('167');">
+	<area shape="circle" coords="81,405,15" title="stop" onclick="pressMenuRemote('128');">
+	<area shape="circle" coords="104,405,15" title="radio" onclick="pressMenuRemote('385');">
 	-->

--- a/BoxBranding/remotes/tm2/remote.html
+++ b/BoxBranding/remotes/tm2/remote.html
@@ -1,40 +1,40 @@
 <img border='0' src='/static/remotes/tm2/rc.png' usemap='#map' >
 <map name="map">
 	<area shape="rect" coords="98,62,118,72" title="mute" onclick="pressMenuRemote('113');">
-	<area shape="rect" coords="51,34,88,52" id ="116" title="Power" onclick="pressMenuRemote('116');">
-	<area shape="rect" coords="22,305,48,315" id ="388" title="text" onclick="pressMenuRemote('388');">
-	<area shape="rect" coords="55,306,83,315" id ="370" title="subtitle" onclick="pressMenuRemote('370');">
-	<area shape="rect" coords="24,36,40,50" id ="102" title="home" onclick="pressMenuRemote('102');">
-	<area shape="rect" coords="97,35,115,51" id ="107" title="end" onclick="pressMenuRemote('107');">
+	<area shape="rect" coords="51,34,88,52" title="Power" onclick="pressMenuRemote('116');">
+	<area shape="rect" coords="22,305,48,315" title="text" onclick="pressMenuRemote('388');">
+	<area shape="rect" coords="55,306,83,315" title="subtitle" onclick="pressMenuRemote('370');">
+	<area shape="rect" coords="24,36,40,50" title="home" onclick="pressMenuRemote('102');">
+	<area shape="rect" coords="97,35,115,51" title="end" onclick="pressMenuRemote('107');">
 
-	<area shape="rect" coords="20,62,40,72" id ="2" title="1" onclick="pressMenuRemote('2');">
-	<area shape="rect" coords="46,62,66,72" id ="3" title="2" onclick="pressMenuRemote('3');">
-	<area shape="rect" coords="72,62,92,72" id ="4" title="3" onclick="pressMenuRemote('4');">
-	<area shape="rect" coords="20,78,40,88" id ="5" title="4" onclick="pressMenuRemote('5');">
-	<area shape="rect" coords="46,78,66,88" id ="6" title="5" onclick="pressMenuRemote('6');">
-	<area shape="rect" coords="72,78,92,88" id ="7" title="6" onclick="pressMenuRemote('7');">
-	<area shape="rect" coords="20,96,40,106" id ="8" title="7" onclick="pressMenuRemote('8');">
-	<area shape="rect" coords="46,96,66,106" id ="9" title="8" onclick="pressMenuRemote('9');">
-	<area shape="rect" coords="72,62,92,106" id ="10" title="9" onclick="pressMenuRemote('10');">
-	<area shape="rect" coords="46,112,66,125" id ="11" title="0" onclick="pressMenuRemote('11');">
+	<area shape="rect" coords="20,62,40,72" title="1" onclick="pressMenuRemote('2');">
+	<area shape="rect" coords="46,62,66,72" title="2" onclick="pressMenuRemote('3');">
+	<area shape="rect" coords="72,62,92,72" title="3" onclick="pressMenuRemote('4');">
+	<area shape="rect" coords="20,78,40,88" title="4" onclick="pressMenuRemote('5');">
+	<area shape="rect" coords="46,78,66,88" title="5" onclick="pressMenuRemote('6');">
+	<area shape="rect" coords="72,78,92,88" title="6" onclick="pressMenuRemote('7');">
+	<area shape="rect" coords="20,96,40,106" title="7" onclick="pressMenuRemote('8');">
+	<area shape="rect" coords="46,96,66,106" title="8" onclick="pressMenuRemote('9');">
+	<area shape="rect" coords="72,62,92,106" title="9" onclick="pressMenuRemote('10');">
+	<area shape="rect" coords="46,112,66,125" title="0" onclick="pressMenuRemote('11');">
 
 	<!-- Added Key -->
 	<area shape="rect" coords="96,95,118,107" title="Lan" onclick="pressMenuRemote(376);">
-	<area shape="circle" coords="104,214,18" id ="174" title="exit" onclick="pressMenuRemote('174');">
+	<area shape="circle" coords="104,214,18" title="exit" onclick="pressMenuRemote('174');">
 
-	<area shape="rect" coords="94,134,117,154" id ="402" title="channelup" onclick="pressMenuRemote('402');">
-	<area shape="rect" coords="94,174,117,194" id ="403" title="channeldown" onclick="pressMenuRemote('403');">
+	<area shape="rect" coords="94,134,117,154" title="channelup" onclick="pressMenuRemote('402');">
+	<area shape="rect" coords="94,174,117,194" title="channeldown" onclick="pressMenuRemote('403');">
 
-	<area shape="rect" coords="20,134,40,154" id ="115" title="volume up" onclick="pressMenuRemote('115');">
-	<area shape="rect" coords="20,174,40,194" id ="114" title="volume down" onclick="pressMenuRemote('114');">
+	<area shape="rect" coords="20,134,40,154" title="volume up" onclick="pressMenuRemote('115');">
+	<area shape="rect" coords="20,174,40,194" title="volume down" onclick="pressMenuRemote('114');">
 
-	<area shape="rect" coords="20,112,40,125" id ="412" title="previous" onclick="pressMenuRemote('412');">
-	<area shape="rect" coords="72,112,92,125" id ="407" title="next" onclick="pressMenuRemote('407');">
+	<area shape="rect" coords="20,112,40,125" title="previous" onclick="pressMenuRemote('412');">
+	<area shape="rect" coords="72,112,92,125" title="next" onclick="pressMenuRemote('407');">
 
-	<area shape="rect" coords="20,323,41,332" id ="398" title="red" onclick="pressMenuRemote('398');">
-	<area shape="rect" coords="45,323,66,332" id ="399" title="green" onclick="pressMenuRemote('399');">
-	<area shape="rect" coords="70,323,91,332" id ="400" title="yellow" onclick="pressMenuRemote('400');">
-	<area shape="rect" coords="95,323,116,332" id ="401" title="blue" onclick="pressMenuRemote('401');">
+	<area shape="rect" coords="20,323,41,332" title="red" onclick="pressMenuRemote('398');">
+	<area shape="rect" coords="45,323,66,332" title="green" onclick="pressMenuRemote('399');">
+	<area shape="rect" coords="70,323,91,332" title="yellow" onclick="pressMenuRemote('400');">
+	<area shape="rect" coords="95,323,116,332" title="blue" onclick="pressMenuRemote('401');">
 
 	<area shape="circle" coords="69,145,10" title="EPGPressed" onclick="pressMenuRemote(365);">
 	<area shape="circle" coords="33,280,10" title="openSatellites" onclick="pressMenuRemote(381);">
@@ -67,80 +67,80 @@
 	<!-- F. -->
 	<area shape="rect" coords="98,114,116,124" title="showRFmod" onclick="pressMenuRemote('172');">
 
-	<area shape="circle" coords="70,213,10" id ="103" title="up" onclick="pressMenuRemote('103');">
-	<area shape="circle" coords="70,283,10" id ="108" title="down" onclick="pressMenuRemote('108');">
-	<area shape="circle" coords="35,248,10" id ="105" title="left" onclick="pressMenuRemote('105');">
-	<area shape="circle" coords="105,248,10" id ="106" title="right" onclick="pressMenuRemote('106');">
+	<area shape="circle" coords="70,213,10" title="up" onclick="pressMenuRemote('103');">
+	<area shape="circle" coords="70,283,10" title="down" onclick="pressMenuRemote('108');">
+	<area shape="circle" coords="35,248,10" title="left" onclick="pressMenuRemote('105');">
+	<area shape="circle" coords="105,248,10" title="right" onclick="pressMenuRemote('106');">
 
-	<area shape="circle" coords="70,248,18" id ="352" title="OK" onclick="pressMenuRemote('352');">
-	<area shape="circle" coords="69,180,15" id ="392" title="audio" onclick="pressMenuRemote('392');">
+	<area shape="circle" coords="70,248,18" title="OK" onclick="pressMenuRemote('352');">
+	<area shape="circle" coords="69,180,15" title="audio" onclick="pressMenuRemote('392');">
 
-	<area shape="circle" coords="32,214,12" id ="139" title="menu" onclick="pressMenuRemote('139');">
-	<area shape="rect" coords="55,365,83,379" id ="167" title="record" onclick="pressMenuRemote('167');">
-	<area shape="rect" coords="20,342,46,357" id ="393" title="videoaltlast" onclick="pressMenuRemote('393');">
+	<area shape="circle" coords="32,214,12" title="menu" onclick="pressMenuRemote('139');">
+	<area shape="rect" coords="55,365,83,379" title="record" onclick="pressMenuRemote('167');">
+	<area shape="rect" coords="20,342,46,357" title="videoaltlast" onclick="pressMenuRemote('393');">
 
-	<area shape="rect" coords="98,78,118,88" id ="138" title="help" onclick="pressMenuRemote('138');">
+	<area shape="rect" coords="98,78,118,88" title="help" onclick="pressMenuRemote('138');">
 
-	<area shape="rect" coords="23,389,48,404" id ="168" title="rewind" onclick="pressMenuRemote('168');">
-	<area shape="rect" coords="57,389,83,404" id ="207" title="play" onclick="pressMenuRemote('207');">
-	<area shape="rect" coords="91,367,117,381" id ="119" title="pause" onclick="pressMenuRemote('119');">
-	<area shape="rect" coords="91,389,117,404" id ="208" title="forward" onclick="pressMenuRemote('208');">
-	<area shape="rect" coords="55,411,82,428" id ="409" title="tv" onclick="pressMenuRemote('409');">
+	<area shape="rect" coords="23,389,48,404" title="rewind" onclick="pressMenuRemote('168');">
+	<area shape="rect" coords="57,389,83,404" title="play" onclick="pressMenuRemote('207');">
+	<area shape="rect" coords="91,367,117,381" title="pause" onclick="pressMenuRemote('119');">
+	<area shape="rect" coords="91,389,117,404" title="forward" onclick="pressMenuRemote('208');">
+	<area shape="rect" coords="55,411,82,428" title="tv" onclick="pressMenuRemote('409');">
 
 
-	<area shape="circle" coords="23,366,48,381" id ="128" title="stop" onclick="pressMenuRemote('128');">
-	<area shape="circle" coords="91,413,116,428" id ="385" title="radio" onclick="pressMenuRemote('385');">
+	<area shape="circle" coords="23,366,48,381" title="stop" onclick="pressMenuRemote('128');">
+	<area shape="circle" coords="91,413,116,428" title="radio" onclick="pressMenuRemote('385');">
 
 	
-	<area shape="rect" coords="98,112,118,122" id ="371" title="pip" onclick="pressMenuRemote('371');">
+	<area shape="rect" coords="98,112,118,122" title="pip" onclick="pressMenuRemote('371');">
 	
-	<area shape="circle" coords="105,279,12" id ="358" title="Info" onclick="pressMenuRemote('358');">
+	<area shape="circle" coords="105,279,12" title="Info" onclick="pressMenuRemote('358');">
 
 </map>
 <!--
 	<area shape="circle" coords="33,28,15" title="mute" onclick="pressMenuRemote('113');">
-	<area shape="circle" coords="105,28,15" id ="116" title="Power" onclick="pressMenuRemote('116');">
-	<area shape="circle" coords="33,53,15" id ="388" title="text" onclick="pressMenuRemote('388');">
-	<area shape="circle" coords="58,53,15" id ="370" title="subtitle" onclick="pressMenuRemote('370');">
-	<area shape="circle" coords="82,53,15" id ="102" title="home" onclick="pressMenuRemote('102');">
-	<area shape="circle" coords="105,53,15" id ="107" title="end" onclick="pressMenuRemote('107');">
-	<area shape="circle" coords="38,79,15" id ="2" title="1" onclick="pressMenuRemote('2');">
-	<area shape="circle" coords="70,79,15" id ="3" title="2" onclick="pressMenuRemote('3');">
-	<area shape="circle" coords="102,79,15" id ="4" title="3" onclick="pressMenuRemote('4');">
-	<area shape="circle" coords="38,106,15" id ="5" title="4" onclick="pressMenuRemote('5');">
-	<area shape="circle" coords="70,106,15" id ="6" title="5" onclick="pressMenuRemote('6');">
-	<area shape="circle" coords="102,106,15" id ="7" title="6" onclick="pressMenuRemote('7');">
-	<area shape="circle" coords="38,133,15" id ="8" title="7" onclick="pressMenuRemote('8');">
-	<area shape="circle" coords="70,133,15" id ="9" title="8" onclick="pressMenuRemote('9');">
-	<area shape="circle" coords="102,133,15" id ="10" title="9" onclick="pressMenuRemote('10');">
-	<area shape="circle" coords="38,161,15" id ="412" title="previous" onclick="pressMenuRemote('412');">
-	<area shape="circle" coords="70,161,15" id ="11" title="0" onclick="pressMenuRemote('11');">
-	<area shape="circle" coords="102,161,15" id ="407" title="next" onclick="pressMenuRemote('407');">
-	<area shape="circle" coords="33,186,15" id ="398" title="red" onclick="pressMenuRemote('398');">
-	<area shape="circle" coords="58,186,15" id ="399" title="green" onclick="pressMenuRemote('399');">
-	<area shape="circle" coords="82,186,15" id ="400" title="yellow" onclick="pressMenuRemote('400');">
-	<area shape="circle" coords="105,186,15" id ="401" title="blue" onclick="pressMenuRemote('401');">
-	<area shape="circle" coords="70,213,15" id ="103" title="up" onclick="pressMenuRemote('103');">
-	<area shape="circle" coords="70,283,15" id ="108" title="down" onclick="pressMenuRemote('108');">
-	<area shape="circle" coords="35,248,15" id ="105" title="left" onclick="pressMenuRemote('105');">
-	<area shape="circle" coords="105,248,15" id ="106" title="right" onclick="pressMenuRemote('106');">
-	<area shape="circle" coords="70,248,20" id ="352" title="OK" onclick="pressMenuRemote('352');">
-	<area shape="circle" coords="40,307,15" id ="115" title="volume up" onclick="pressMenuRemote('115');">
-	<area shape="circle" coords="40,338,13" id ="114" title="volume down" onclick="pressMenuRemote('114');">
-	<area shape="circle" coords="70,310,15" id ="174" title="exit" onclick="pressMenuRemote('174');">
-	<area shape="circle" coords="70,334,15" id ="358" title="epg" onclick="pressMenuRemote('358');">
-	<area shape="circle" coords="99,307,15" id ="402" title="channelup" onclick="pressMenuRemote('402');">
-	<area shape="circle" coords="99,338,15" id ="403" title="channeldown" onclick="pressMenuRemote('403');">
-	<area shape="circle" coords="36,362,15" id ="139" title="menu" onclick="pressMenuRemote('139');">
-	<area shape="circle" coords="59,362,15" id ="393" title="videoaltlast" onclick="pressMenuRemote('393');">
-	<area shape="circle" coords="81,362,15" id ="392" title="audio" onclick="pressMenuRemote('392');">
-	<area shape="circle" coords="104,362,15" id ="138" title="help" onclick="pressMenuRemote('138');">
-	<area shape="circle" coords="36,383,15" id ="168" title="rewind" onclick="pressMenuRemote('168');">
-	<area shape="circle" coords="59,383,15" id ="207" title="play" onclick="pressMenuRemote('207');">
-	<area shape="circle" coords="81,383,15" id ="119" title="pause" onclick="pressMenuRemote('119');">
-	<area shape="circle" coords="104,383,15" id ="208" title="forward" onclick="pressMenuRemote('208');">
-	<area shape="circle" coords="36,405,15" id ="377" title="tv" onclick="pressMenuRemote('377');">
-	<area shape="circle" coords="59,405,15" id ="167" title="record" onclick="pressMenuRemote('167');">
-	<area shape="circle" coords="81,405,15" id ="128" title="stop" onclick="pressMenuRemote('128');">
-	<area shape="circle" coords="104,405,15" id ="385" title="radio" onclick="pressMenuRemote('385');">
+	<area shape="circle" coords="105,28,15" title="Power" onclick="pressMenuRemote('116');">
+	<area shape="circle" coords="33,53,15" title="text" onclick="pressMenuRemote('388');">
+	<area shape="circle" coords="58,53,15" title="subtitle" onclick="pressMenuRemote('370');">
+	<area shape="circle" coords="82,53,15" title="home" onclick="pressMenuRemote('102');">
+	<area shape="circle" coords="105,53,15" title="end" onclick="pressMenuRemote('107');">
+	<area shape="circle" coords="38,79,15" title="1" onclick="pressMenuRemote('2');">
+	<area shape="circle" coords="70,79,15" title="2" onclick="pressMenuRemote('3');">
+	<area shape="circle" coords="102,79,15" title="3" onclick="pressMenuRemote('4');">
+	<area shape="circle" coords="38,106,15" title="4" onclick="pressMenuRemote('5');">
+	<area shape="circle" coords="70,106,15" title="5" onclick="pressMenuRemote('6');">
+	<area shape="circle" coords="102,106,15" title="6" onclick="pressMenuRemote('7');">
+	<area shape="circle" coords="38,133,15" title="7" onclick="pressMenuRemote('8');">
+	<area shape="circle" coords="70,133,15" title="8" onclick="pressMenuRemote('9');">
+	<area shape="circle" coords="102,133,15" title="9" onclick="pressMenuRemote('10');">
+	<area shape="circle" coords="38,161,15" title="previous" onclick="pressMenuRemote('412');">
+	<area shape="circle" coords="70,161,15" title="0" onclick="pressMenuRemote('11');">
+	<area shape="circle" coords="102,161,15" title="next" onclick="pressMenuRemote('407');">
+	<area shape="circle" coords="33,186,15" title="red" onclick="pressMenuRemote('398');">
+	<area shape="circle" coords="58,186,15" title="green" onclick="pressMenuRemote('399');">
+	<area shape="circle" coords="82,186,15" title="yellow" onclick="pressMenuRemote('400');">
+	<area shape="circle" coords="105,186,15" title="blue" onclick="pressMenuRemote('401');">
+	<area shape="circle" coords="70,213,15" title="up" onclick="pressMenuRemote('103');">
+	<area shape="circle" coords="70,283,15" title="down" onclick="pressMenuRemote('108');">
+	<area shape="circle" coords="35,248,15" title="left" onclick="pressMenuRemote('105');">
+	<area shape="circle" coords="105,248,15" title="right" onclick="pressMenuRemote('106');">
+	<area shape="circle" coords="70,248,20" title="OK" onclick="pressMenuRemote('352');">
+	<area shape="circle" coords="40,307,15" title="volume up" onclick="pressMenuRemote('115');">
+	<area shape="circle" coords="40,338,13" title="volume down" onclick="pressMenuRemote('114');">
+	<area shape="circle" coords="70,310,15" title="exit" onclick="pressMenuRemote('174');">
+	<area shape="circle" coords="70,334,15" title="epg" onclick="pressMenuRemote('358');">
+	<area shape="circle" coords="99,307,15" title="channelup" onclick="pressMenuRemote('402');">
+	<area shape="circle" coords="99,338,15" title="channeldown" onclick="pressMenuRemote('403');">
+	<area shape="circle" coords="36,362,15" title="menu" onclick="pressMenuRemote('139');">
+	<area shape="circle" coords="59,362,15" title="videoaltlast" onclick="pressMenuRemote('393');">
+	<area shape="circle" coords="81,362,15" title="audio" onclick="pressMenuRemote('392');">
+	<area shape="circle" coords="104,362,15" title="help" onclick="pressMenuRemote('138');">
+	<area shape="circle" coords="36,383,15" title="rewind" onclick="pressMenuRemote('168');">
+	<area shape="circle" coords="59,383,15" title="play" onclick="pressMenuRemote('207');">
+	<area shape="circle" coords="81,383,15" title="pause" onclick="pressMenuRemote('119');">
+	<area shape="circle" coords="104,383,15" title="forward" onclick="pressMenuRemote('208');">
+	<area shape="circle" coords="36,405,15" title="tv" onclick="pressMenuRemote('377');">
+	<area shape="circle" coords="59,405,15" title="record" onclick="pressMenuRemote('167');">
+	<area shape="circle" coords="81,405,15" title="stop" onclick="pressMenuRemote('128');">
+	<area shape="circle" coords="104,405,15" title="radio" onclick="pressMenuRemote('385');">
 	-->

--- a/BoxBranding/remotes/tm3/remote.html
+++ b/BoxBranding/remotes/tm3/remote.html
@@ -1,40 +1,40 @@
 <img border='0' src='/static/remotes/tm3/rc.png' usemap='#map' >
 <map name="map">
 	<area shape="rect" coords="92,19,105,32" title="mute" onclick="pressMenuRemote('113');">
-	<area shape="rect" coords="33,18,50,35" id ="116" title="Power" onclick="pressMenuRemote('116');">
-	<area shape="rect" coords="50,248,65,256" id ="388" title="text" onclick="pressMenuRemote('388');">
-	<area shape="rect" coords="73,248,88,256" id ="370" title="subtitle" onclick="pressMenuRemote('370');">
-	<area shape="rect" coords="60,46,79,58" id ="102" title="home" onclick="pressMenuRemote('102');">
-	<area shape="rect" coords="88,46,109,58" id ="107" title="end" onclick="pressMenuRemote('107');">
+	<area shape="rect" coords="33,18,50,35" title="Power" onclick="pressMenuRemote('116');">
+	<area shape="rect" coords="50,248,65,256" title="text" onclick="pressMenuRemote('388');">
+	<area shape="rect" coords="73,248,88,256" title="subtitle" onclick="pressMenuRemote('370');">
+	<area shape="rect" coords="60,46,79,58" title="home" onclick="pressMenuRemote('102');">
+	<area shape="rect" coords="88,46,109,58" title="end" onclick="pressMenuRemote('107');">
 
-	<area shape="rect" coords="32,87,50,100" id ="2" title="1" onclick="pressMenuRemote('2');">
-	<area shape="rect" coords="62,87,79,100" id ="3" title="2" onclick="pressMenuRemote('3');">
-	<area shape="rect" coords="89,87,107,100" id ="4" title="3" onclick="pressMenuRemote('4');">
-	<area shape="rect" coords="32,109,50,123" id ="5" title="4" onclick="pressMenuRemote('5');">
-	<area shape="rect" coords="62,109,79,123" id ="6" title="5" onclick="pressMenuRemote('6');">
-	<area shape="rect" coords="89,109,107,123" id ="7" title="6" onclick="pressMenuRemote('7');">
-	<area shape="rect" coords="32,132,50,146" id ="8" title="7" onclick="pressMenuRemote('8');">
-	<area shape="rect" coords="62,132,79,146" id ="9" title="8" onclick="pressMenuRemote('9');">
-	<area shape="rect" coords="89,132,107,146" id ="10" title="9" onclick="pressMenuRemote('10');">
-	<area shape="rect" coords="62,156,79,170" id ="11" title="0" onclick="pressMenuRemote('11');">
+	<area shape="rect" coords="32,87,50,100" title="1" onclick="pressMenuRemote('2');">
+	<area shape="rect" coords="62,87,79,100" title="2" onclick="pressMenuRemote('3');">
+	<area shape="rect" coords="89,87,107,100" title="3" onclick="pressMenuRemote('4');">
+	<area shape="rect" coords="32,109,50,123" title="4" onclick="pressMenuRemote('5');">
+	<area shape="rect" coords="62,109,79,123" title="5" onclick="pressMenuRemote('6');">
+	<area shape="rect" coords="89,109,107,123" title="6" onclick="pressMenuRemote('7');">
+	<area shape="rect" coords="32,132,50,146" title="7" onclick="pressMenuRemote('8');">
+	<area shape="rect" coords="62,132,79,146" title="8" onclick="pressMenuRemote('9');">
+	<area shape="rect" coords="89,132,107,146" title="9" onclick="pressMenuRemote('10');">
+	<area shape="rect" coords="62,156,79,170" title="0" onclick="pressMenuRemote('11');">
 
 	<!-- Added Key -->
 	<area shape="rect" coords="89,68,107,78" title="Lan" onclick="pressMenuRemote('376');">
-	<area shape="circle" coords="106,275,8" id ="174" title="exit" onclick="pressMenuRemote('174');">
+	<area shape="circle" coords="106,275,8" title="exit" onclick="pressMenuRemote('174');">
 
-	<area shape="rect" coords="91,183,109,203" id ="402" title="channelup" onclick="pressMenuRemote('402');">
-	<area shape="rect" coords="91,214,109,233" id ="403" title="channeldown" onclick="pressMenuRemote('403');">
+	<area shape="rect" coords="91,183,109,203" title="channelup" onclick="pressMenuRemote('402');">
+	<area shape="rect" coords="91,214,109,233" title="channeldown" onclick="pressMenuRemote('403');">
 
-	<area shape="rect" coords="29,183,47,203" id ="115" title="volume up" onclick="pressMenuRemote('115');">
-	<area shape="rect" coords="29,214,47,233" id ="114" title="volume down" onclick="pressMenuRemote('114');">
+	<area shape="rect" coords="29,183,47,203" title="volume up" onclick="pressMenuRemote('115');">
+	<area shape="rect" coords="29,214,47,233" title="volume down" onclick="pressMenuRemote('114');">
 
-	<area shape="rect" coords="29,153,51,171" id ="412" title="previous" onclick="pressMenuRemote('412');">
-	<area shape="rect" coords="85,153,110,171" id ="407" title="next" onclick="pressMenuRemote('407');">
+	<area shape="rect" coords="29,153,51,171" title="previous" onclick="pressMenuRemote('412');">
+	<area shape="rect" coords="85,153,110,171" title="next" onclick="pressMenuRemote('407');">
 
-	<area shape="rect" coords="27,361,42,371" id ="398" title="red" onclick="pressMenuRemote('398');">
-	<area shape="rect" coords="50,361,66,371" id ="399" title="green" onclick="pressMenuRemote('399');">
-	<area shape="rect" coords="71,361,89,371" id ="400" title="yellow" onclick="pressMenuRemote('400');">
-	<area shape="rect" coords="95,361,112,371" id ="401" title="blue" onclick="pressMenuRemote('401');">
+	<area shape="rect" coords="27,361,42,371" title="red" onclick="pressMenuRemote('398');">
+	<area shape="rect" coords="50,361,66,371" title="green" onclick="pressMenuRemote('399');">
+	<area shape="rect" coords="71,361,89,371" title="yellow" onclick="pressMenuRemote('400');">
+	<area shape="rect" coords="95,361,112,371" title="blue" onclick="pressMenuRemote('401');">
 
 	<area shape="circle" coords="69,194,8" title="EPGPressed" onclick="pressMenuRemote(365);">
 	<area shape="circle" coords="33,344,8" title="openSatellites" onclick="pressMenuRemote(381);">
@@ -67,29 +67,29 @@
 	<!-- Rf modulator -->
 	<!--<area shape="rect" coords="98,114,116,124" title="showRFmod" onclick="pressMenuRemote(63);">-->
 
-	<area shape="circle" coords="69,282,8" id ="103" title="up" onclick="pressMenuRemote('103');">
-	<area shape="circle" coords="69,336,8" id ="108" title="down" onclick="pressMenuRemote('108');">
-	<area shape="circle" coords="41,309,8" id ="105" title="left" onclick="pressMenuRemote('105');">
-	<area shape="circle" coords="96,309,8" id ="106" title="right" onclick="pressMenuRemote('106');">
+	<area shape="circle" coords="69,282,8" title="up" onclick="pressMenuRemote('103');">
+	<area shape="circle" coords="69,336,8" title="down" onclick="pressMenuRemote('108');">
+	<area shape="circle" coords="41,309,8" title="left" onclick="pressMenuRemote('105');">
+	<area shape="circle" coords="96,309,8" title="right" onclick="pressMenuRemote('106');">
 
-	<area shape="circle" coords="69,309,12" id ="352" title="OK" onclick="pressMenuRemote('352');">
-	<area shape="circle" coords="35,252,8" id ="392" title="audio" onclick="pressMenuRemote('392');">
+	<area shape="circle" coords="69,309,12" title="OK" onclick="pressMenuRemote('352');">
+	<area shape="circle" coords="35,252,8" title="audio" onclick="pressMenuRemote('392');">
 
-	<area shape="circle" coords="32,275,8" id ="139" title="menu" onclick="pressMenuRemote('139');">
-	<area shape="rect" coords="50,403,65,413" id ="167" title="record" onclick="pressMenuRemote('167');">
-	<area shape="rect" coords="99,337,114,352" id ="393" title="videoaltlast" onclick="pressMenuRemote('393');">
+	<area shape="circle" coords="32,275,8" title="menu" onclick="pressMenuRemote('139');">
+	<area shape="rect" coords="50,403,65,413" title="record" onclick="pressMenuRemote('167');">
+	<area shape="rect" coords="99,337,114,352" title="videoaltlast" onclick="pressMenuRemote('393');">
 
-	<area shape="rect" coords="31,48,49,58" id ="138" title="help" onclick="pressMenuRemote('138');">
+	<area shape="rect" coords="31,48,49,58" title="help" onclick="pressMenuRemote('138');">
 
-	<area shape="rect" coords="25,384,43,396" id ="168" title="rewind" onclick="pressMenuRemote('168');">
-	<area shape="rect" coords="48,384,67,396" id ="207" title="play" onclick="pressMenuRemote('207');">
-	<area shape="rect" coords="72,384,88,396" id ="119" title="pause" onclick="pressMenuRemote('119');">
-	<area shape="rect" coords="95,304,112,396" id ="208" title="forward" onclick="pressMenuRemote('208');">
-	<area shape="rect" coords="27,402,43,413" id ="377" title="tv" onclick="pressMenuRemote('377');">
+	<area shape="rect" coords="25,384,43,396" title="rewind" onclick="pressMenuRemote('168');">
+	<area shape="rect" coords="48,384,67,396" title="play" onclick="pressMenuRemote('207');">
+	<area shape="rect" coords="72,384,88,396" title="pause" onclick="pressMenuRemote('119');">
+	<area shape="rect" coords="95,304,112,396" title="forward" onclick="pressMenuRemote('208');">
+	<area shape="rect" coords="27,402,43,413" title="tv" onclick="pressMenuRemote('377');">
 
 
-	<area shape="rect" coords="72,402,88,413" id ="128" title="stop" onclick="pressMenuRemote('128');">
-	<area shape="rect" coords="95,402,110,413" id ="385" title="radio" onclick="pressMenuRemote('385');">
-	<area shape="circle" coords="69,224,10" id ="358" title="Info" onclick="pressMenuRemote('358');">
+	<area shape="rect" coords="72,402,88,413" title="stop" onclick="pressMenuRemote('128');">
+	<area shape="rect" coords="95,402,110,413" title="radio" onclick="pressMenuRemote('385');">
+	<area shape="circle" coords="69,224,10" title="Info" onclick="pressMenuRemote('358');">
 </map>
 

--- a/BoxBranding/remotes/tm4/remote.html
+++ b/BoxBranding/remotes/tm4/remote.html
@@ -1,40 +1,40 @@
 <img border='0' src='/static/remotes/tm4/rc.png' usemap='#map' >
 <map name="map">
 	<area shape="rect" coords="92,19,105,32" title="mute" onclick="pressMenuRemote('113');">
-	<area shape="rect" coords="33,18,50,35" id ="116" title="Power" onclick="pressMenuRemote('116');">
-	<area shape="rect" coords="50,248,65,256" id ="388" title="text" onclick="pressMenuRemote('388');">
-	<area shape="rect" coords="73,248,88,256" id ="370" title="subtitle" onclick="pressMenuRemote('370');">
-	<area shape="rect" coords="60,46,79,58" id ="172" title="home" onclick="pressMenuRemote('172');">
-	<area shape="rect" coords="88,46,109,58" id ="107" title="end" onclick="pressMenuRemote('107');">
+	<area shape="rect" coords="33,18,50,35" title="Power" onclick="pressMenuRemote('116');">
+	<area shape="rect" coords="50,248,65,256" title="text" onclick="pressMenuRemote('388');">
+	<area shape="rect" coords="73,248,88,256" title="subtitle" onclick="pressMenuRemote('370');">
+	<area shape="rect" coords="60,46,79,58" title="home" onclick="pressMenuRemote('172');">
+	<area shape="rect" coords="88,46,109,58" title="end" onclick="pressMenuRemote('107');">
 
-	<area shape="rect" coords="32,87,50,100" id ="2" title="1" onclick="pressMenuRemote('2');">
-	<area shape="rect" coords="62,87,79,100" id ="3" title="2" onclick="pressMenuRemote('3');">
-	<area shape="rect" coords="89,87,107,100" id ="4" title="3" onclick="pressMenuRemote('4');">
-	<area shape="rect" coords="32,109,50,123" id ="5" title="4" onclick="pressMenuRemote('5');">
-	<area shape="rect" coords="62,109,79,123" id ="6" title="5" onclick="pressMenuRemote('6');">
-	<area shape="rect" coords="89,109,107,123" id ="7" title="6" onclick="pressMenuRemote('7');">
-	<area shape="rect" coords="32,132,50,146" id ="8" title="7" onclick="pressMenuRemote('8');">
-	<area shape="rect" coords="62,132,79,146" id ="9" title="8" onclick="pressMenuRemote('9');">
-	<area shape="rect" coords="89,132,107,146" id ="10" title="9" onclick="pressMenuRemote('10');">
-	<area shape="rect" coords="62,156,79,170" id ="11" title="0" onclick="pressMenuRemote('11');">
+	<area shape="rect" coords="32,87,50,100" title="1" onclick="pressMenuRemote('2');">
+	<area shape="rect" coords="62,87,79,100" title="2" onclick="pressMenuRemote('3');">
+	<area shape="rect" coords="89,87,107,100" title="3" onclick="pressMenuRemote('4');">
+	<area shape="rect" coords="32,109,50,123" title="4" onclick="pressMenuRemote('5');">
+	<area shape="rect" coords="62,109,79,123" title="5" onclick="pressMenuRemote('6');">
+	<area shape="rect" coords="89,109,107,123" title="6" onclick="pressMenuRemote('7');">
+	<area shape="rect" coords="32,132,50,146" title="7" onclick="pressMenuRemote('8');">
+	<area shape="rect" coords="62,132,79,146" title="8" onclick="pressMenuRemote('9');">
+	<area shape="rect" coords="89,132,107,146" title="9" onclick="pressMenuRemote('10');">
+	<area shape="rect" coords="62,156,79,170" title="0" onclick="pressMenuRemote('11');">
 
 	<!-- Added Key -->
 	<area shape="rect" coords="89,68,107,78" title="Lan" onclick="pressMenuRemote(376);">
-	<area shape="circle" coords="106,275,8" id ="174" title="exit" onclick="pressMenuRemote('174');">
+	<area shape="circle" coords="106,275,8" title="exit" onclick="pressMenuRemote('174');">
 
-	<area shape="rect" coords="91,183,109,203" id ="402" title="channelup" onclick="pressMenuRemote('402');">
-	<area shape="rect" coords="91,214,109,233" id ="403" title="channeldown" onclick="pressMenuRemote('403');">
+	<area shape="rect" coords="91,183,109,203" title="channelup" onclick="pressMenuRemote('402');">
+	<area shape="rect" coords="91,214,109,233" title="channeldown" onclick="pressMenuRemote('403');">
 
-	<area shape="rect" coords="29,183,47,203" id ="115" title="volume up" onclick="pressMenuRemote('115');">
-	<area shape="rect" coords="29,214,47,233" id ="114" title="volume down" onclick="pressMenuRemote('114');">
+	<area shape="rect" coords="29,183,47,203" title="volume up" onclick="pressMenuRemote('115');">
+	<area shape="rect" coords="29,214,47,233" title="volume down" onclick="pressMenuRemote('114');">
 
-	<area shape="rect" coords="29,153,52,171" id ="412" title="previous" onclick="pressMenuRemote('412');">
-	<area shape="rect" coords="86,155,109,171" id ="407" title="next" onclick="pressMenuRemote('407');">
+	<area shape="rect" coords="29,153,52,171" title="previous" onclick="pressMenuRemote('412');">
+	<area shape="rect" coords="86,155,109,171" title="next" onclick="pressMenuRemote('407');">
 
-	<area shape="rect" coords="27,361,42,371" id ="398" title="red" onclick="pressMenuRemote('398');">
-	<area shape="rect" coords="50,361,66,371" id ="399" title="green" onclick="pressMenuRemote('399');">
-	<area shape="rect" coords="71,361,89,371" id ="400" title="yellow" onclick="pressMenuRemote('400');">
-	<area shape="rect" coords="95,361,112,371" id ="401" title="blue" onclick="pressMenuRemote('401');">
+	<area shape="rect" coords="27,361,42,371" title="red" onclick="pressMenuRemote('398');">
+	<area shape="rect" coords="50,361,66,371" title="green" onclick="pressMenuRemote('399');">
+	<area shape="rect" coords="71,361,89,371" title="yellow" onclick="pressMenuRemote('400');">
+	<area shape="rect" coords="95,361,112,371" title="blue" onclick="pressMenuRemote('401');">
 
 	<area shape="circle" coords="69,194,8" title="EPGPressed" onclick="pressMenuRemote(365);">
 	<area shape="circle" coords="33,344,8" title="openSatellites" onclick="pressMenuRemote(381);">
@@ -67,80 +67,80 @@
 	<!-- Rf modulator -->
 	<!-- <area shape="rect" coords="59,65,80,79" title="showRFmod" onclick="pressMenuRemote(63);"> -->
 
-	<area shape="circle" coords="69,282,8" id ="103" title="up" onclick="pressMenuRemote('103');">
-	<area shape="circle" coords="69,336,8" id ="108" title="down" onclick="pressMenuRemote('108');">
-	<area shape="circle" coords="41,309,8" id ="105" title="left" onclick="pressMenuRemote('105');">
-	<area shape="circle" coords="96,309,8" id ="106" title="right" onclick="pressMenuRemote('106');">
+	<area shape="circle" coords="69,282,8" title="up" onclick="pressMenuRemote('103');">
+	<area shape="circle" coords="69,336,8" title="down" onclick="pressMenuRemote('108');">
+	<area shape="circle" coords="41,309,8" title="left" onclick="pressMenuRemote('105');">
+	<area shape="circle" coords="96,309,8" title="right" onclick="pressMenuRemote('106');">
 
-	<area shape="circle" coords="69,309,12" id ="352" title="OK" onclick="pressMenuRemote('352');">
-	<area shape="circle" coords="35,252,8" id ="392" title="audio" onclick="pressMenuRemote('392');">
+	<area shape="circle" coords="69,309,12" title="OK" onclick="pressMenuRemote('352');">
+	<area shape="circle" coords="35,252,8" title="audio" onclick="pressMenuRemote('392');">
 
-	<area shape="circle" coords="32,275,8" id ="139" title="menu" onclick="pressMenuRemote('139');">
-	<area shape="rect" coords="50,442,64,432" id ="167" title="record" onclick="pressMenuRemote('167');">
-	<area shape="rect" coords="26,385,43,394" id ="393" title="videoaltlast" onclick="pressMenuRemote('393');">
+	<area shape="circle" coords="32,275,8" title="menu" onclick="pressMenuRemote('139');">
+	<area shape="rect" coords="50,442,64,432" title="record" onclick="pressMenuRemote('167');">
+	<area shape="rect" coords="26,385,43,394" title="videoaltlast" onclick="pressMenuRemote('393');">
 
-	<area shape="rect" coords="31,48,49,58" id ="138" title="help" onclick="pressMenuRemote('138');">
+	<area shape="rect" coords="31,48,49,58" title="help" onclick="pressMenuRemote('138');">
 
-	<area shape="rect" coords="27,403,42,413" id ="168" title="rewind" onclick="pressMenuRemote('168');">
-	<area shape="rect" coords="49,403,65,413" id ="207" title="play" onclick="pressMenuRemote('207');">
-	<area shape="rect" coords="72,404,88,413" id ="119" title="pause" onclick="pressMenuRemote('119');">
-	<area shape="rect" coords="95,404,110,413" id ="208" title="forward" onclick="pressMenuRemote('208');">
-	<area shape="rect" coords="27,421,43,431" id ="377" title="tv" onclick="pressMenuRemote('377');">
+	<area shape="rect" coords="27,403,42,413" title="rewind" onclick="pressMenuRemote('168');">
+	<area shape="rect" coords="49,403,65,413" title="play" onclick="pressMenuRemote('207');">
+	<area shape="rect" coords="72,404,88,413" title="pause" onclick="pressMenuRemote('119');">
+	<area shape="rect" coords="95,404,110,413" title="forward" onclick="pressMenuRemote('208');">
+	<area shape="rect" coords="27,421,43,431" title="tv" onclick="pressMenuRemote('377');">
 
 
-	<area shape="rect" coords="72,421,88,431" id ="128" title="stop" onclick="pressMenuRemote('128');">
-	<area shape="rect" coords="95,422,110,430" id ="385" title="radio" onclick="pressMenuRemote('385');">
+	<area shape="rect" coords="72,421,88,431" title="stop" onclick="pressMenuRemote('128');">
+	<area shape="rect" coords="95,422,110,430" title="radio" onclick="pressMenuRemote('385');">
 
-	<area shape="circle" coords="69,224,10" id ="358" title="Info" onclick="pressMenuRemote('358');">
-	<area shape="rect" coords="98,336,114,351" id ="406" title="prov" onclick="pressMenuRemote('406');">
-	<area shape="rect" coords="59,65,80,79" id ="394" title="ytube" onclick="pressMenuRemote('394');">
-	<area shape="rect" coords="94,384,112,395" id ="375" title="pip" onclick="pressMenuRemote('375');">
-	<area shape="rect" coords="71,384,89,395" id ="59" title="f1" onclick="pressMenuRemote('59');">
+	<area shape="circle" coords="69,224,10" title="Info" onclick="pressMenuRemote('358');">
+	<area shape="rect" coords="98,336,114,351" title="prov" onclick="pressMenuRemote('406');">
+	<area shape="rect" coords="59,65,80,79" title="ytube" onclick="pressMenuRemote('394');">
+	<area shape="rect" coords="94,384,112,395" title="pip" onclick="pressMenuRemote('375');">
+	<area shape="rect" coords="71,384,89,395" title="f1" onclick="pressMenuRemote('59');">
 </map>
 <!--
 	<area shape="circle" coords="33,28,15" title="mute" onclick="pressMenuRemote('113');">
-	<area shape="circle" coords="105,28,15" id ="116" title="Power" onclick="pressMenuRemote('116');">
-	<area shape="circle" coords="33,53,15" id ="388" title="text" onclick="pressMenuRemote('388');">
-	<area shape="circle" coords="58,53,15" id ="370" title="subtitle" onclick="pressMenuRemote('370');">
-	<area shape="circle" coords="82,53,15" id ="102" title="home" onclick="pressMenuRemote('102');">
-	<area shape="circle" coords="105,53,15" id ="107" title="end" onclick="pressMenuRemote('107');">
-	<area shape="circle" coords="38,79,15" id ="2" title="1" onclick="pressMenuRemote('2');">
-	<area shape="circle" coords="70,79,15" id ="3" title="2" onclick="pressMenuRemote('3');">
-	<area shape="circle" coords="102,79,15" id ="4" title="3" onclick="pressMenuRemote('4');">
-	<area shape="circle" coords="38,106,15" id ="5" title="4" onclick="pressMenuRemote('5');">
-	<area shape="circle" coords="70,106,15" id ="6" title="5" onclick="pressMenuRemote('6');">
-	<area shape="circle" coords="102,106,15" id ="7" title="6" onclick="pressMenuRemote('7');">
-	<area shape="circle" coords="38,133,15" id ="8" title="7" onclick="pressMenuRemote('8');">
-	<area shape="circle" coords="70,133,15" id ="9" title="8" onclick="pressMenuRemote('9');">
-	<area shape="circle" coords="102,133,15" id ="10" title="9" onclick="pressMenuRemote('10');">
-	<area shape="circle" coords="38,161,15" id ="412" title="previous" onclick="pressMenuRemote('412');">
-	<area shape="circle" coords="70,161,15" id ="11" title="0" onclick="pressMenuRemote('11');">
-	<area shape="circle" coords="102,161,15" id ="407" title="next" onclick="pressMenuRemote('407');">
-	<area shape="circle" coords="33,186,15" id ="398" title="red" onclick="pressMenuRemote('398');">
-	<area shape="circle" coords="58,186,15" id ="399" title="green" onclick="pressMenuRemote('399');">
-	<area shape="circle" coords="82,186,15" id ="400" title="yellow" onclick="pressMenuRemote('400');">
-	<area shape="circle" coords="105,186,15" id ="401" title="blue" onclick="pressMenuRemote('401');">
-	<area shape="circle" coords="70,213,15" id ="103" title="up" onclick="pressMenuRemote('103');">
-	<area shape="circle" coords="70,283,15" id ="108" title="down" onclick="pressMenuRemote('108');">
-	<area shape="circle" coords="35,248,15" id ="105" title="left" onclick="pressMenuRemote('105');">
-	<area shape="circle" coords="105,248,15" id ="106" title="right" onclick="pressMenuRemote('106');">
-	<area shape="circle" coords="70,248,20" id ="352" title="OK" onclick="pressMenuRemote('352');">
-	<area shape="circle" coords="40,307,15" id ="115" title="volume up" onclick="pressMenuRemote('115');">
-	<area shape="circle" coords="40,338,13" id ="114" title="volume down" onclick="pressMenuRemote('114');">
-	<area shape="circle" coords="70,310,15" id ="174" title="exit" onclick="pressMenuRemote('174');">
-	<area shape="circle" coords="70,334,15" id ="358" title="epg" onclick="pressMenuRemote('358');">
-	<area shape="circle" coords="99,307,15" id ="402" title="channelup" onclick="pressMenuRemote('402');">
-	<area shape="circle" coords="99,338,15" id ="403" title="channeldown" onclick="pressMenuRemote('403');">
-	<area shape="circle" coords="36,362,15" id ="139" title="menu" onclick="pressMenuRemote('139');">
-	<area shape="circle" coords="59,362,15" id ="393" title="videoaltlast" onclick="pressMenuRemote('393');">
-	<area shape="circle" coords="81,362,15" id ="392" title="audio" onclick="pressMenuRemote('392');">
-	<area shape="circle" coords="104,362,15" id ="138" title="help" onclick="pressMenuRemote('138');">
-	<area shape="circle" coords="36,383,15" id ="168" title="rewind" onclick="pressMenuRemote('168');">
-	<area shape="circle" coords="59,383,15" id ="207" title="play" onclick="pressMenuRemote('207');">
-	<area shape="circle" coords="81,383,15" id ="119" title="pause" onclick="pressMenuRemote('119');">
-	<area shape="circle" coords="104,383,15" id ="208" title="forward" onclick="pressMenuRemote('208');">
-	<area shape="circle" coords="36,405,15" id ="377" title="tv" onclick="pressMenuRemote('377');">
-	<area shape="circle" coords="59,405,15" id ="167" title="record" onclick="pressMenuRemote('167');">
-	<area shape="circle" coords="81,405,15" id ="128" title="stop" onclick="pressMenuRemote('128');">
-	<area shape="circle" coords="104,405,15" id ="385" title="radio" onclick="pressMenuRemote('385');">
+	<area shape="circle" coords="105,28,15" title="Power" onclick="pressMenuRemote('116');">
+	<area shape="circle" coords="33,53,15" title="text" onclick="pressMenuRemote('388');">
+	<area shape="circle" coords="58,53,15" title="subtitle" onclick="pressMenuRemote('370');">
+	<area shape="circle" coords="82,53,15" title="home" onclick="pressMenuRemote('102');">
+	<area shape="circle" coords="105,53,15" title="end" onclick="pressMenuRemote('107');">
+	<area shape="circle" coords="38,79,15" title="1" onclick="pressMenuRemote('2');">
+	<area shape="circle" coords="70,79,15" title="2" onclick="pressMenuRemote('3');">
+	<area shape="circle" coords="102,79,15" title="3" onclick="pressMenuRemote('4');">
+	<area shape="circle" coords="38,106,15" title="4" onclick="pressMenuRemote('5');">
+	<area shape="circle" coords="70,106,15" title="5" onclick="pressMenuRemote('6');">
+	<area shape="circle" coords="102,106,15" title="6" onclick="pressMenuRemote('7');">
+	<area shape="circle" coords="38,133,15" title="7" onclick="pressMenuRemote('8');">
+	<area shape="circle" coords="70,133,15" title="8" onclick="pressMenuRemote('9');">
+	<area shape="circle" coords="102,133,15" title="9" onclick="pressMenuRemote('10');">
+	<area shape="circle" coords="38,161,15" title="previous" onclick="pressMenuRemote('412');">
+	<area shape="circle" coords="70,161,15" title="0" onclick="pressMenuRemote('11');">
+	<area shape="circle" coords="102,161,15" title="next" onclick="pressMenuRemote('407');">
+	<area shape="circle" coords="33,186,15" title="red" onclick="pressMenuRemote('398');">
+	<area shape="circle" coords="58,186,15" title="green" onclick="pressMenuRemote('399');">
+	<area shape="circle" coords="82,186,15" title="yellow" onclick="pressMenuRemote('400');">
+	<area shape="circle" coords="105,186,15" title="blue" onclick="pressMenuRemote('401');">
+	<area shape="circle" coords="70,213,15" title="up" onclick="pressMenuRemote('103');">
+	<area shape="circle" coords="70,283,15" title="down" onclick="pressMenuRemote('108');">
+	<area shape="circle" coords="35,248,15" title="left" onclick="pressMenuRemote('105');">
+	<area shape="circle" coords="105,248,15" title="right" onclick="pressMenuRemote('106');">
+	<area shape="circle" coords="70,248,20" title="OK" onclick="pressMenuRemote('352');">
+	<area shape="circle" coords="40,307,15" title="volume up" onclick="pressMenuRemote('115');">
+	<area shape="circle" coords="40,338,13" title="volume down" onclick="pressMenuRemote('114');">
+	<area shape="circle" coords="70,310,15" title="exit" onclick="pressMenuRemote('174');">
+	<area shape="circle" coords="70,334,15" title="epg" onclick="pressMenuRemote('358');">
+	<area shape="circle" coords="99,307,15" title="channelup" onclick="pressMenuRemote('402');">
+	<area shape="circle" coords="99,338,15" title="channeldown" onclick="pressMenuRemote('403');">
+	<area shape="circle" coords="36,362,15" title="menu" onclick="pressMenuRemote('139');">
+	<area shape="circle" coords="59,362,15" title="videoaltlast" onclick="pressMenuRemote('393');">
+	<area shape="circle" coords="81,362,15" title="audio" onclick="pressMenuRemote('392');">
+	<area shape="circle" coords="104,362,15" title="help" onclick="pressMenuRemote('138');">
+	<area shape="circle" coords="36,383,15" title="rewind" onclick="pressMenuRemote('168');">
+	<area shape="circle" coords="59,383,15" title="play" onclick="pressMenuRemote('207');">
+	<area shape="circle" coords="81,383,15" title="pause" onclick="pressMenuRemote('119');">
+	<area shape="circle" coords="104,383,15" title="forward" onclick="pressMenuRemote('208');">
+	<area shape="circle" coords="36,405,15" title="tv" onclick="pressMenuRemote('377');">
+	<area shape="circle" coords="59,405,15" title="record" onclick="pressMenuRemote('167');">
+	<area shape="circle" coords="81,405,15" title="stop" onclick="pressMenuRemote('128');">
+	<area shape="circle" coords="104,405,15" title="radio" onclick="pressMenuRemote('385');">
 	-->

--- a/BoxBranding/remotes/tm5/remote.html
+++ b/BoxBranding/remotes/tm5/remote.html
@@ -1,71 +1,71 @@
 <img border='0' src='/static/remotes/tm5/rc.png' usemap='#map' >
 <map name="map">
-	<area shape="rect" coords="31, 24, 50, 45" id ="116" title="Power" onclick="pressMenuRemote('116');">
-	<area shape="rect" coords="89, 27,104, 42" id ="113" title="mute" onclick="pressMenuRemote('113');">
+	<area shape="rect" coords="31, 24, 50, 45" title="Power" onclick="pressMenuRemote('116');">
+	<area shape="rect" coords="89, 27,104, 42" title="mute" onclick="pressMenuRemote('113');">
 		
-	<area shape="rect" coords="30, 53, 52, 66" id ="138" title="help" onclick="pressMenuRemote('138');">
-	<area shape="rect" coords="58, 53, 80, 66" id ="102" title="home" onclick="pressMenuRemote('102');">
-	<area shape="rect" coords="86, 53,109, 66" id ="376" title="Lan" onclick="pressMenuRemote('376');">
+	<area shape="rect" coords="30, 53, 52, 66" title="help" onclick="pressMenuRemote('138');">
+	<area shape="rect" coords="58, 53, 80, 66" title="home" onclick="pressMenuRemote('102');">
+	<area shape="rect" coords="86, 53,109, 66" title="Lan" onclick="pressMenuRemote('376');">
 
-	<area shape="rect" coords="30, 73, 52, 85" id ="372" title="ZoomInOut" onclick="pressMenuRemote('372');">
-	<area shape="rect" coords="58, 73, 80, 85" id ="107" title="end" onclick="pressMenuRemote('107');">
-	<area shape="rect" coords="86, 73,108, 85" id ="394" title="plugin" onclick="pressMenuRemote('394');">
+	<area shape="rect" coords="30, 73, 52, 85" title="ZoomInOut" onclick="pressMenuRemote('372');">
+	<area shape="rect" coords="58, 73, 80, 85" title="end" onclick="pressMenuRemote('107');">
+	<area shape="rect" coords="86, 73,108, 85" title="plugin" onclick="pressMenuRemote('394');">
 
-	<area shape="rect" coords="31, 91, 51,108" id ="2" title="1" onclick="pressMenuRemote('2');">
-	<area shape="rect" coords="58, 91, 79,108" id ="3" title="2" onclick="pressMenuRemote('3');">
-	<area shape="rect" coords="87, 91,108,108" id ="4" title="3" onclick="pressMenuRemote('4');">
-	<area shape="rect" coords="31,114, 51,130" id ="5" title="4" onclick="pressMenuRemote('5');">
-	<area shape="rect" coords="58,114, 79,130" id ="6" title="5" onclick="pressMenuRemote('6');">
-	<area shape="rect" coords="87,114,108,130" id ="7" title="6" onclick="pressMenuRemote('7');">
-	<area shape="rect" coords="31,137, 51,151" id ="8" title="7" onclick="pressMenuRemote('8');">
-	<area shape="rect" coords="58,137, 79,151" id ="9" title="8" onclick="pressMenuRemote('9');">
-	<area shape="rect" coords="87,137,108,151" id ="10" title="9" onclick="pressMenuRemote('10');">
-	<area shape="rect" coords="31,160, 51,174" id ="412" title="previous" onclick="pressMenuRemote('412');">
-	<area shape="rect" coords="58,160, 81,174" id ="11" title="0" onclick="pressMenuRemote('11');">
-	<area shape="rect" coords="87,160,108,174" id ="407" title="next" onclick="pressMenuRemote('407');">
+	<area shape="rect" coords="31, 91, 51,108" title="1" onclick="pressMenuRemote('2');">
+	<area shape="rect" coords="58, 91, 79,108" title="2" onclick="pressMenuRemote('3');">
+	<area shape="rect" coords="87, 91,108,108" title="3" onclick="pressMenuRemote('4');">
+	<area shape="rect" coords="31,114, 51,130" title="4" onclick="pressMenuRemote('5');">
+	<area shape="rect" coords="58,114, 79,130" title="5" onclick="pressMenuRemote('6');">
+	<area shape="rect" coords="87,114,108,130" title="6" onclick="pressMenuRemote('7');">
+	<area shape="rect" coords="31,137, 51,151" title="7" onclick="pressMenuRemote('8');">
+	<area shape="rect" coords="58,137, 79,151" title="8" onclick="pressMenuRemote('9');">
+	<area shape="rect" coords="87,137,108,151" title="9" onclick="pressMenuRemote('10');">
+	<area shape="rect" coords="31,160, 51,174" title="previous" onclick="pressMenuRemote('412');">
+	<area shape="rect" coords="58,160, 81,174" title="0" onclick="pressMenuRemote('11');">
+	<area shape="rect" coords="87,160,108,174" title="next" onclick="pressMenuRemote('407');">
 
-	<area shape="rect" coords="27,185, 52,208" id ="115" title="volume up" onclick="pressMenuRemote('115');">
-	<area shape="rect" coords="27,215, 52,238" id ="114" title="volume down" onclick="pressMenuRemote('114');">
-	<area shape="rect" coords="87,185,110,208" id ="402" title="channelup" onclick="pressMenuRemote('402');">
-	<area shape="rect" coords="87,215,110,238" id ="403" title="channeldown" onclick="pressMenuRemote('403');">
-	<area shape="rect" coords="61,189, 78,206" id ="365" title="EPGPressed" onclick="pressMenuRemote('365');">
-	<area shape="rect" coords="61,218, 78,233" id ="358" title="info" onclick="pressMenuRemote('358');">
+	<area shape="rect" coords="27,185, 52,208" title="volume up" onclick="pressMenuRemote('115');">
+	<area shape="rect" coords="27,215, 52,238" title="volume down" onclick="pressMenuRemote('114');">
+	<area shape="rect" coords="87,185,110,208" title="channelup" onclick="pressMenuRemote('402');">
+	<area shape="rect" coords="87,215,110,238" title="channeldown" onclick="pressMenuRemote('403');">
+	<area shape="rect" coords="61,189, 78,206" title="EPGPressed" onclick="pressMenuRemote('365');">
+	<area shape="rect" coords="61,218, 78,233" title="info" onclick="pressMenuRemote('358');">
 
-	<area shape="rect" coords="26,248, 45,261" id ="392" title="audio" onclick="pressMenuRemote('392');">
-	<area shape="rect" coords="48,248, 66,261" id ="388" title="startTeletext" onclick="pressMenuRemote('388');">
-	<area shape="rect" coords="71,248, 89,261" id ="370" title="subtitle" onclick="pressMenuRemote('370');">
-	<area shape="rect" coords="93,248,110,261" id ="362" title="openTimerList" onclick="pressMenuRemote('362');">
+	<area shape="rect" coords="26,248, 45,261" title="audio" onclick="pressMenuRemote('392');">
+	<area shape="rect" coords="48,248, 66,261" title="startTeletext" onclick="pressMenuRemote('388');">
+	<area shape="rect" coords="71,248, 89,261" title="subtitle" onclick="pressMenuRemote('370');">
+	<area shape="rect" coords="93,248,110,261" title="openTimerList" onclick="pressMenuRemote('362');">
 
-	<area shape="rect" coords="25,268, 41,284" id ="139" title="menu" onclick="pressMenuRemote('139');">
-	<area shape="rect" coords="97,268,113,284" id ="174" title="exit" onclick="pressMenuRemote('174');">
-	<area shape="rect" coords="25,335, 41,351" id ="381" title="openSatellites" onclick="pressMenuRemote('381');">
-	<area shape="rect" coords="97,335,113,351" id ="406" title="prov" onclick="pressMenuRemote('406');">
+	<area shape="rect" coords="25,268, 41,284" title="menu" onclick="pressMenuRemote('139');">
+	<area shape="rect" coords="97,268,113,284" title="exit" onclick="pressMenuRemote('174');">
+	<area shape="rect" coords="25,335, 41,351" title="openSatellites" onclick="pressMenuRemote('381');">
+	<area shape="rect" coords="97,335,113,351" title="prov" onclick="pressMenuRemote('406');">
 
-	<area shape="rect" coords="49,277, 88,293" id ="103" title="up" onclick="pressMenuRemote('103');">
-	<area shape="rect" coords="51,328, 86,344" id ="108" title="down" onclick="pressMenuRemote('108');">
-	<area shape="rect" coords="36,294, 52,326" id ="105" title="left" onclick="pressMenuRemote('105');">
-	<area shape="rect" coords="83,294,103,326" id ="106" title="right" onclick="pressMenuRemote('106');">
-	<area shape="rect" coords="56,298, 81,322" id ="352" title="OK" onclick="pressMenuRemote('352');">
+	<area shape="rect" coords="49,277, 88,293" title="up" onclick="pressMenuRemote('103');">
+	<area shape="rect" coords="51,328, 86,344" title="down" onclick="pressMenuRemote('108');">
+	<area shape="rect" coords="36,294, 52,326" title="left" onclick="pressMenuRemote('105');">
+	<area shape="rect" coords="83,294,103,326" title="right" onclick="pressMenuRemote('106');">
+	<area shape="rect" coords="56,298, 81,322" title="OK" onclick="pressMenuRemote('352');">
 
-	<area shape="rect" coords="25,360, 45,372" id ="398" title="red" onclick="pressMenuRemote('398');">
-	<area shape="rect" coords="48,360, 67,372" id ="399" title="green" onclick="pressMenuRemote('399');">
-	<area shape="rect" coords="71,360, 89,372" id ="400" title="yellow" onclick="pressMenuRemote('400');">
-	<area shape="rect" coords="93,360,113,372" id ="401" title="blue" onclick="pressMenuRemote('401');">
+	<area shape="rect" coords="25,360, 45,372" title="red" onclick="pressMenuRemote('398');">
+	<area shape="rect" coords="48,360, 67,372" title="green" onclick="pressMenuRemote('399');">
+	<area shape="rect" coords="71,360, 89,372" title="yellow" onclick="pressMenuRemote('400');">
+	<area shape="rect" coords="93,360,113,372" title="blue" onclick="pressMenuRemote('401');">
 
-	<area shape="rect" coords="25,383, 45,394" id ="393" title="showMovies" onclick="pressMenuRemote('393');">
-	<area shape="rect" coords="48,383, 67,394" id ="395" title="showMediaPlayer" onclick="pressMenuRemote('395');">
-	<area shape="rect" coords="71,383, 89,394" id ="59" title="f1" onclick="pressMenuRemote('59');">
-	<area shape="rect" coords="93,383,113,394" id ="60" title="f2" onclick="pressMenuRemote('60');">
-	<area shape="rect" coords="87,72,108,85" id ="394" title="plugins" onclick="pressMenuRemote('394');">
+	<area shape="rect" coords="25,383, 45,394" title="showMovies" onclick="pressMenuRemote('393');">
+	<area shape="rect" coords="48,383, 67,394" title="showMediaPlayer" onclick="pressMenuRemote('395');">
+	<area shape="rect" coords="71,383, 89,394" title="f1" onclick="pressMenuRemote('59');">
+	<area shape="rect" coords="93,383,113,394" title="f2" onclick="pressMenuRemote('60');">
+	<area shape="rect" coords="87,72,108,85" title="plugins" onclick="pressMenuRemote('394');">
 
-	<area shape="rect" coords="25,400, 44,412" id ="168" title="rewind" onclick="pressMenuRemote('168');">
-	<area shape="rect" coords="48,400, 67,412" id ="207" title="play" onclick="pressMenuRemote('207');">
-	<area shape="rect" coords="71,400, 89,412" id ="119" title="pause" onclick="pressMenuRemote('119');">
-	<area shape="rect" coords="71,400, 89,412" id ="164" title="timeshiftStart" onclick="pressMenuRemote('164');">
-	<area shape="rect" coords="93,400,113,412" id ="208" title="forward" onclick="pressMenuRemote('208');">
+	<area shape="rect" coords="25,400, 44,412" title="rewind" onclick="pressMenuRemote('168');">
+	<area shape="rect" coords="48,400, 67,412" title="play" onclick="pressMenuRemote('207');">
+	<area shape="rect" coords="71,400, 89,412" title="pause" onclick="pressMenuRemote('119');">
+	<area shape="rect" coords="71,400, 89,412" title="timeshiftStart" onclick="pressMenuRemote('164');">
+	<area shape="rect" coords="93,400,113,412" title="forward" onclick="pressMenuRemote('208');">
 
-	<area shape="rect" coords="25,418, 44,430" id ="377" title="tv" onclick="pressMenuRemote('377');">
-	<area shape="rect" coords="48,418, 67,430" id ="167" title="record" onclick="pressMenuRemote('167');">
-	<area shape="rect" coords="71,418, 89,430" id ="128" title="timeshiftStop" onclick="pressMenuRemote('128');">	
-	<area shape="rect" coords="93,418,113,430" id ="385" title="radio" onclick="pressMenuRemote('385');">
+	<area shape="rect" coords="25,418, 44,430" title="tv" onclick="pressMenuRemote('377');">
+	<area shape="rect" coords="48,418, 67,430" title="record" onclick="pressMenuRemote('167');">
+	<area shape="rect" coords="71,418, 89,430" title="timeshiftStop" onclick="pressMenuRemote('128');">	
+	<area shape="rect" coords="93,418,113,430" title="radio" onclick="pressMenuRemote('385');">
 </map>

--- a/BoxBranding/remotes/tm6/remote.html
+++ b/BoxBranding/remotes/tm6/remote.html
@@ -1,66 +1,66 @@
 <img border='0' src='/static/remotes/tm6/rc.png' usemap='#map' >
 <map name="map">
 	<!-- brand: technomate, model : tmtwin4k rcu with universal functionality -->
-	<area shape="circle" coords="41,35,11" id ="116" title="Power" onclick="pressMenuRemote('116');">	
-	<area shape="circle" coords="97,35,7" id ="113" title="mute" onclick="pressMenuRemote('113');">
+	<area shape="circle" coords="41,35,11" title="Power" onclick="pressMenuRemote('116');">	
+	<area shape="circle" coords="97,35,7" title="mute" onclick="pressMenuRemote('113');">
 		
-	<area shape="rect" coords="30,53,52,67" id ="138" title="help" onclick="pressMenuRemote('138');">	
-	<area shape="rect" coords="58,53,79,67" id ="102" title="home" onclick="pressMenuRemote('102');">	
-	<area shape="rect" coords="85,53,107,67" id ="107" title="end" onclick="pressMenuRemote('107');">
+	<area shape="rect" coords="30,53,52,67" title="help" onclick="pressMenuRemote('138');">	
+	<area shape="rect" coords="58,53,79,67" title="home" onclick="pressMenuRemote('102');">	
+	<area shape="rect" coords="85,53,107,67" title="end" onclick="pressMenuRemote('107');">
 
-	<area shape="rect" coords="30,72,51,85" id ="375" title="pip" onclick="pressMenuRemote('375');">
-	<area shape="rect" coords="58,72,79,85" id ="395" title="showMediaPlayer" onclick="pressMenuRemote('395');">
-	<area shape="rect" coords="85,72,107,85" id ="376" title="Lan" onclick="pressMenuRemote('376');">
+	<area shape="rect" coords="30,72,51,85" title="pip" onclick="pressMenuRemote('375');">
+	<area shape="rect" coords="58,72,79,85" title="showMediaPlayer" onclick="pressMenuRemote('395');">
+	<area shape="rect" coords="85,72,107,85" title="Lan" onclick="pressMenuRemote('376');">
 	
-	<area shape="rect" coords="31,93,49,107" id ="2" title="1" onclick="pressMenuRemote('2');">
-	<area shape="rect" coords="56,93,79,107" id ="3" title="2" onclick="pressMenuRemote('3');">	
-	<area shape="rect" coords="86,93,108,107" id ="4" title="3" onclick="pressMenuRemote('4');">
-	<area shape="rect" coords="31,117,49,130" id ="5" title="4" onclick="pressMenuRemote('5');">
-	<area shape="rect" coords="56,117,79,130" id ="6" title="5" onclick="pressMenuRemote('6');">
-	<area shape="rect" coords="86,117,108,130" id ="7" title="6" onclick="pressMenuRemote('7');">
-	<area shape="rect" coords="31,138,49,154" id ="8" title="7" onclick="pressMenuRemote('8');">
-	<area shape="rect" coords="56,138,79,154" id ="9" title="8" onclick="pressMenuRemote('9');">
-	<area shape="rect" coords="86,138,108,154" id ="10" title="9" onclick="pressMenuRemote('10');">
-	<area shape="rect" coords="31,160,49,175" id ="412" title="previous" onclick="pressMenuRemote('412');">
-	<area shape="rect" coords="56,160,79,175" id ="11" title="0" onclick="pressMenuRemote('11');">
-	<area shape="rect" coords="86,160,108,175" id ="407" title="next" onclick="pressMenuRemote('407');">
+	<area shape="rect" coords="31,93,49,107" title="1" onclick="pressMenuRemote('2');">
+	<area shape="rect" coords="56,93,79,107" title="2" onclick="pressMenuRemote('3');">	
+	<area shape="rect" coords="86,93,108,107" title="3" onclick="pressMenuRemote('4');">
+	<area shape="rect" coords="31,117,49,130" title="4" onclick="pressMenuRemote('5');">
+	<area shape="rect" coords="56,117,79,130" title="5" onclick="pressMenuRemote('6');">
+	<area shape="rect" coords="86,117,108,130" title="6" onclick="pressMenuRemote('7');">
+	<area shape="rect" coords="31,138,49,154" title="7" onclick="pressMenuRemote('8');">
+	<area shape="rect" coords="56,138,79,154" title="8" onclick="pressMenuRemote('9');">
+	<area shape="rect" coords="86,138,108,154" title="9" onclick="pressMenuRemote('10');">
+	<area shape="rect" coords="31,160,49,175" title="previous" onclick="pressMenuRemote('412');">
+	<area shape="rect" coords="56,160,79,175" title="0" onclick="pressMenuRemote('11');">
+	<area shape="rect" coords="86,160,108,175" title="next" onclick="pressMenuRemote('407');">
 
-	<area shape="circle" coords="39,197,13" id ="115" title="volume up" onclick="pressMenuRemote('115');">
-	<area shape="circle" coords="39,227,13" id ="114" title="volume down" onclick="pressMenuRemote('114');">
-	<area shape="circle" coords="99,197,13" id ="402" title="channelup" onclick="pressMenuRemote('402');">
-	<area shape="circle" coords="99,227,13" id ="403" title="channeldown" onclick="pressMenuRemote('403');">
-	<area shape="circle" coords="68,197,7" id ="365" title="EPGPressed" onclick="pressMenuRemote('365');">
-	<area shape="circle" coords="68,227,7" id ="358" title="info" onclick="pressMenuRemote('358');">
+	<area shape="circle" coords="39,197,13" title="volume up" onclick="pressMenuRemote('115');">
+	<area shape="circle" coords="39,227,13" title="volume down" onclick="pressMenuRemote('114');">
+	<area shape="circle" coords="99,197,13" title="channelup" onclick="pressMenuRemote('402');">
+	<area shape="circle" coords="99,227,13" title="channeldown" onclick="pressMenuRemote('403');">
+	<area shape="circle" coords="68,197,7" title="EPGPressed" onclick="pressMenuRemote('365');">
+	<area shape="circle" coords="68,227,7" title="info" onclick="pressMenuRemote('358');">
 
-	<area shape="rect" coords="26,250,43,260" id ="392" title="audio" onclick="pressMenuRemote('392');">
-	<area shape="rect" coords="48,250,64,260" id ="388" title="startTeletext" onclick="pressMenuRemote('388');">
-	<area shape="rect" coords="72,250,87,260" id ="370" title="subtitle" onclick="pressMenuRemote('370');">
-	<area shape="rect" coords="94,250,108,260" id ="362" title="openTimerList" onclick="pressMenuRemote('362');">
+	<area shape="rect" coords="26,250,43,260" title="audio" onclick="pressMenuRemote('392');">
+	<area shape="rect" coords="48,250,64,260" title="startTeletext" onclick="pressMenuRemote('388');">
+	<area shape="rect" coords="72,250,87,260" title="subtitle" onclick="pressMenuRemote('370');">
+	<area shape="rect" coords="94,250,108,260" title="openTimerList" onclick="pressMenuRemote('362');">
 
-	<area shape="circle" coords="32,276,7" id ="139" title="menu" onclick="pressMenuRemote('139');">
-	<area shape="circle" coords="105,276,7" id ="174" title="exit" onclick="pressMenuRemote('174');">
-	<area shape="circle" coords="32,344,7" id ="381" title="openSatellites" onclick="pressMenuRemote('381');">
-	<area shape="circle" coords="105,344,7" id ="393" title="showMovies" onclick="pressMenuRemote('393');">
+	<area shape="circle" coords="32,276,7" title="menu" onclick="pressMenuRemote('139');">
+	<area shape="circle" coords="105,276,7" title="exit" onclick="pressMenuRemote('174');">
+	<area shape="circle" coords="32,344,7" title="openSatellites" onclick="pressMenuRemote('381');">
+	<area shape="circle" coords="105,344,7" title="showMovies" onclick="pressMenuRemote('393');">
 
-	<area shape="rect" coords="55,277,85,291" id ="103" title="up" onclick="pressMenuRemote('103');">
-	<area shape="rect" coords="55,329,85,344" id ="108" title="down" onclick="pressMenuRemote('108');">
-	<area shape="rect" coords="36,296,52,326" id ="105" title="left" onclick="pressMenuRemote('105');">
-	<area shape="rect" coords="87,296,102,326" id ="106" title="right" onclick="pressMenuRemote('106');">
-	<area shape="circle" coords="69,311,14" id ="352" title="OK" onclick="pressMenuRemote('352');">
+	<area shape="rect" coords="55,277,85,291" title="up" onclick="pressMenuRemote('103');">
+	<area shape="rect" coords="55,329,85,344" title="down" onclick="pressMenuRemote('108');">
+	<area shape="rect" coords="36,296,52,326" title="left" onclick="pressMenuRemote('105');">
+	<area shape="rect" coords="87,296,102,326" title="right" onclick="pressMenuRemote('106');">
+	<area shape="circle" coords="69,311,14" title="OK" onclick="pressMenuRemote('352');">
 
-	<area shape="rect" coords="26,359,45,372" id ="398" title="red" onclick="pressMenuRemote('398');">
-	<area shape="rect" coords="47,359,67,372" id ="399" title="green" onclick="pressMenuRemote('399');">
-	<area shape="rect" coords="70,359,89,372" id ="400" title="yellow" onclick="pressMenuRemote('400');">
-	<area shape="rect" coords="93,359,111,372" id ="401" title="blue" onclick="pressMenuRemote('401');">
+	<area shape="rect" coords="26,359,45,372" title="red" onclick="pressMenuRemote('398');">
+	<area shape="rect" coords="47,359,67,372" title="green" onclick="pressMenuRemote('399');">
+	<area shape="rect" coords="70,359,89,372" title="yellow" onclick="pressMenuRemote('400');">
+	<area shape="rect" coords="93,359,111,372" title="blue" onclick="pressMenuRemote('401');">
 
-	<area shape="rect" coords="26,383,45,396" id ="168" title="rewind" onclick="pressMenuRemote('168');">
-	<area shape="rect" coords="47,383,67,396" id ="207" title="play" onclick="pressMenuRemote('207');">
-	<area shape="rect" coords="70,383,89,396" id ="119" title="pause" onclick="pressMenuRemote('119');">
-	<area shape="rect" coords="70,383,89,396" id ="164" title="timeshiftStart" onclick="pressMenuRemote('164');">
-	<area shape="rect" coords="93,383,111,396" id ="208" title="forward" onclick="pressMenuRemote('208');">
+	<area shape="rect" coords="26,383,45,396" title="rewind" onclick="pressMenuRemote('168');">
+	<area shape="rect" coords="47,383,67,396" title="play" onclick="pressMenuRemote('207');">
+	<area shape="rect" coords="70,383,89,396" title="pause" onclick="pressMenuRemote('119');">
+	<area shape="rect" coords="70,383,89,396" title="timeshiftStart" onclick="pressMenuRemote('164');">
+	<area shape="rect" coords="93,383,111,396" title="forward" onclick="pressMenuRemote('208');">
 
-	<area shape="rect" coords="26,402,45,413" id ="377" title="tv" onclick="pressMenuRemote('377');">
-	<area shape="rect" coords="47,402,67,413" id ="167" title="record" onclick="pressMenuRemote('167');">
-	<area shape="rect" coords="70,402,89,413" id ="128" title="timeshiftStop" onclick="pressMenuRemote('128');">	
-	<area shape="rect" coords="93,402,111,413" id ="385" title="radio" onclick="pressMenuRemote('385');">
+	<area shape="rect" coords="26,402,45,413" title="tv" onclick="pressMenuRemote('377');">
+	<area shape="rect" coords="47,402,67,413" title="record" onclick="pressMenuRemote('167');">
+	<area shape="rect" coords="70,402,89,413" title="timeshiftStop" onclick="pressMenuRemote('128');">	
+	<area shape="rect" coords="93,402,111,413" title="radio" onclick="pressMenuRemote('385');">
 </map>

--- a/BoxBranding/remotes/turing/remote.html
+++ b/BoxBranding/remotes/turing/remote.html
@@ -1,40 +1,40 @@
 <img border='0' src='/static/remotes/turing/rc.png' usemap='#map' >
 <map name="map">
 	<area shape="rect" coords="98,62,118,72" title="mute" onclick="pressMenuRemote('113');">
-	<area shape="rect" coords="105,28,15" id ="116" title="Power" onclick="pressMenuRemote('116');">
-	<area shape="rect" coords="33,53,15" id ="388" title="text" onclick="pressMenuRemote('388');">
-	<area shape="rect" coords="58,53,15" id ="370" title="subtitle" onclick="pressMenuRemote('370');">
-	<area shape="rect" coords="82,53,15" id ="102" title="home" onclick="pressMenuRemote('102');">
-	<area shape="rect" coords="105,53,15" id ="107" title="end" onclick="pressMenuRemote('107');">
+	<area shape="rect" coords="105,28,15" title="Power" onclick="pressMenuRemote('116');">
+	<area shape="rect" coords="33,53,15" title="text" onclick="pressMenuRemote('388');">
+	<area shape="rect" coords="58,53,15" title="subtitle" onclick="pressMenuRemote('370');">
+	<area shape="rect" coords="82,53,15" title="home" onclick="pressMenuRemote('102');">
+	<area shape="rect" coords="105,53,15" title="end" onclick="pressMenuRemote('107');">
 
-	<area shape="rect" coords="20,62,40,72" id ="2" title="1" onclick="pressMenuRemote('2');">
-	<area shape="rect" coords="46,62,66,72" id ="3" title="2" onclick="pressMenuRemote('3');">
-	<area shape="rect" coords="72,62,92,72" id ="4" title="3" onclick="pressMenuRemote('4');">
-	<area shape="rect" coords="20,78,40,88" id ="5" title="4" onclick="pressMenuRemote('5');">
-	<area shape="rect" coords="46,78,66,88" id ="6" title="5" onclick="pressMenuRemote('6');">
-	<area shape="rect" coords="72,78,92,88" id ="7" title="6" onclick="pressMenuRemote('7');">
-	<area shape="rect" coords="20,96,40,106" id ="8" title="7" onclick="pressMenuRemote('8');">
-	<area shape="rect" coords="46,96,66,106" id ="9" title="8" onclick="pressMenuRemote('9');">
-	<area shape="rect" coords="72,62,92,106" id ="10" title="9" onclick="pressMenuRemote('10');">
-	<area shape="rect" coords="46,112,66,125" id ="11" title="0" onclick="pressMenuRemote('11');">
+	<area shape="rect" coords="20,62,40,72" title="1" onclick="pressMenuRemote('2');">
+	<area shape="rect" coords="46,62,66,72" title="2" onclick="pressMenuRemote('3');">
+	<area shape="rect" coords="72,62,92,72" title="3" onclick="pressMenuRemote('4');">
+	<area shape="rect" coords="20,78,40,88" title="4" onclick="pressMenuRemote('5');">
+	<area shape="rect" coords="46,78,66,88" title="5" onclick="pressMenuRemote('6');">
+	<area shape="rect" coords="72,78,92,88" title="6" onclick="pressMenuRemote('7');">
+	<area shape="rect" coords="20,96,40,106" title="7" onclick="pressMenuRemote('8');">
+	<area shape="rect" coords="46,96,66,106" title="8" onclick="pressMenuRemote('9');">
+	<area shape="rect" coords="72,62,92,106" title="9" onclick="pressMenuRemote('10');">
+	<area shape="rect" coords="46,112,66,125" title="0" onclick="pressMenuRemote('11');">
 
 	<!-- Added Key -->
 	<area shape="rect" coords="96,95,118,107" title="Lan" onclick="pressMenuRemote(59);">
-	<area shape="circle" coords="104,214,18" id ="174" title="exit" onclick="pressMenuRemote('174');">
+	<area shape="circle" coords="104,214,18" title="exit" onclick="pressMenuRemote('174');">
 
-	<area shape="rect" coords="94,134,117,154" id ="402" title="channelup" onclick="pressMenuRemote('402');">
-	<area shape="rect" coords="94,174,117,194" id ="403" title="channeldown" onclick="pressMenuRemote('403');">
+	<area shape="rect" coords="94,134,117,154" title="channelup" onclick="pressMenuRemote('402');">
+	<area shape="rect" coords="94,174,117,194" title="channeldown" onclick="pressMenuRemote('403');">
 
-	<area shape="rect" coords="20,134,40,154" id ="115" title="volume up" onclick="pressMenuRemote('115');">
-	<area shape="rect" coords="20,174,40,194" id ="114" title="volume down" onclick="pressMenuRemote('114');">
+	<area shape="rect" coords="20,134,40,154" title="volume up" onclick="pressMenuRemote('115');">
+	<area shape="rect" coords="20,174,40,194" title="volume down" onclick="pressMenuRemote('114');">
 
-	<area shape="rect" coords="20,112,40,125" id ="412" title="previous" onclick="pressMenuRemote('412');">
-	<area shape="rect" coords="72,112,92,125" id ="407" title="next" onclick="pressMenuRemote('407');">
+	<area shape="rect" coords="20,112,40,125" title="previous" onclick="pressMenuRemote('412');">
+	<area shape="rect" coords="72,112,92,125" title="next" onclick="pressMenuRemote('407');">
 
-	<area shape="rect" coords="20,323,41,332" id ="398" title="red" onclick="pressMenuRemote('398');">
-	<area shape="rect" coords="45,323,66,332" id ="399" title="green" onclick="pressMenuRemote('399');">
-	<area shape="rect" coords="70,323,91,332" id ="400" title="yellow" onclick="pressMenuRemote('400');">
-	<area shape="rect" coords="95,323,116,332" id ="401" title="blue" onclick="pressMenuRemote('401');">
+	<area shape="rect" coords="20,323,41,332" title="red" onclick="pressMenuRemote('398');">
+	<area shape="rect" coords="45,323,66,332" title="green" onclick="pressMenuRemote('399');">
+	<area shape="rect" coords="70,323,91,332" title="yellow" onclick="pressMenuRemote('400');">
+	<area shape="rect" coords="95,323,116,332" title="blue" onclick="pressMenuRemote('401');">
 
 	<area shape="circle" coords="69,145,15" title="EPGPressed" onclick="pressMenuRemote(365);">
 	<area shape="circle" coords="33,280,20" title="openSatellites" onclick="pressMenuRemote(381);">
@@ -67,74 +67,74 @@
 	<!-- Rf modulator -->
 	<area shape="rect" coords="98,114,116,124" title="showRFmod" onclick="pressMenuRemote(63);">
 
-	<area shape="circle" coords="70,213,15" id ="103" title="up" onclick="pressMenuRemote('103');">
-	<area shape="circle" coords="70,283,15" id ="108" title="down" onclick="pressMenuRemote('108');">
-	<area shape="circle" coords="35,248,15" id ="105" title="left" onclick="pressMenuRemote('105');">
-	<area shape="circle" coords="105,248,15" id ="106" title="right" onclick="pressMenuRemote('106');">
+	<area shape="circle" coords="70,213,15" title="up" onclick="pressMenuRemote('103');">
+	<area shape="circle" coords="70,283,15" title="down" onclick="pressMenuRemote('108');">
+	<area shape="circle" coords="35,248,15" title="left" onclick="pressMenuRemote('105');">
+	<area shape="circle" coords="105,248,15" title="right" onclick="pressMenuRemote('106');">
 
-	<area shape="circle" coords="70,248,20" id ="352" title="OK" onclick="pressMenuRemote('352');">
-	<area shape="circle" coords="69,180,15" id ="392" title="audio" onclick="pressMenuRemote('392');">
+	<area shape="circle" coords="70,248,20" title="OK" onclick="pressMenuRemote('352');">
+	<area shape="circle" coords="69,180,15" title="audio" onclick="pressMenuRemote('392');">
 
-	<area shape="circle" coords="32,214,18" id ="139" title="menu" onclick="pressMenuRemote('139');">
-	<area shape="rect" coords="55,342,82,358" id ="167" title="record" onclick="pressMenuRemote('167');">
-	<area shape="rect" coords="20,342,46,357" id ="393" title="videoaltlast" onclick="pressMenuRemote('393');">
+	<area shape="circle" coords="32,214,18" title="menu" onclick="pressMenuRemote('139');">
+	<area shape="rect" coords="55,342,82,358" title="record" onclick="pressMenuRemote('167');">
+	<area shape="rect" coords="20,342,46,357" title="videoaltlast" onclick="pressMenuRemote('393');">
 
-	<area shape="rect" coords="98,78,118,88" id ="138" title="help" onclick="pressMenuRemote('138');">
+	<area shape="rect" coords="98,78,118,88" title="help" onclick="pressMenuRemote('138');">
 
-	<area shape="circle" coords="36,383,15" id ="168" title="rewind" onclick="pressMenuRemote('168');">
-	<area shape="circle" coords="59,383,15" id ="207" title="play" onclick="pressMenuRemote('207');">
-	<area shape="circle" coords="81,383,15" id ="119" title="pause" onclick="pressMenuRemote('119');">
-	<area shape="circle" coords="104,383,15" id ="208" title="forward" onclick="pressMenuRemote('208');">
-	<area shape="circle" coords="36,405,15" id ="377" title="tv" onclick="pressMenuRemote('377');">
+	<area shape="circle" coords="36,383,15" title="rewind" onclick="pressMenuRemote('168');">
+	<area shape="circle" coords="59,383,15" title="play" onclick="pressMenuRemote('207');">
+	<area shape="circle" coords="81,383,15" title="pause" onclick="pressMenuRemote('119');">
+	<area shape="circle" coords="104,383,15" title="forward" onclick="pressMenuRemote('208');">
+	<area shape="circle" coords="36,405,15" title="tv" onclick="pressMenuRemote('377');">
 
 
-	<area shape="circle" coords="81,405,15" id ="128" title="stop" onclick="pressMenuRemote('128');">
-	<area shape="circle" coords="104,405,15" id ="385" title="radio" onclick="pressMenuRemote('385');">
+	<area shape="circle" coords="81,405,15" title="stop" onclick="pressMenuRemote('128');">
+	<area shape="circle" coords="104,405,15" title="radio" onclick="pressMenuRemote('385');">
 </map>
 <!--
 	<area shape="circle" coords="33,28,15" title="mute" onclick="pressMenuRemote('113');">
-	<area shape="circle" coords="105,28,15" id ="116" title="Power" onclick="pressMenuRemote('116');">
-	<area shape="circle" coords="33,53,15" id ="388" title="text" onclick="pressMenuRemote('388');">
-	<area shape="circle" coords="58,53,15" id ="370" title="subtitle" onclick="pressMenuRemote('370');">
-	<area shape="circle" coords="82,53,15" id ="102" title="home" onclick="pressMenuRemote('102');">
-	<area shape="circle" coords="105,53,15" id ="107" title="end" onclick="pressMenuRemote('107');">
-	<area shape="circle" coords="38,79,15" id ="2" title="1" onclick="pressMenuRemote('2');">
-	<area shape="circle" coords="70,79,15" id ="3" title="2" onclick="pressMenuRemote('3');">
-	<area shape="circle" coords="102,79,15" id ="4" title="3" onclick="pressMenuRemote('4');">
-	<area shape="circle" coords="38,106,15" id ="5" title="4" onclick="pressMenuRemote('5');">
-	<area shape="circle" coords="70,106,15" id ="6" title="5" onclick="pressMenuRemote('6');">
-	<area shape="circle" coords="102,106,15" id ="7" title="6" onclick="pressMenuRemote('7');">
-	<area shape="circle" coords="38,133,15" id ="8" title="7" onclick="pressMenuRemote('8');">
-	<area shape="circle" coords="70,133,15" id ="9" title="8" onclick="pressMenuRemote('9');">
-	<area shape="circle" coords="102,133,15" id ="10" title="9" onclick="pressMenuRemote('10');">
-	<area shape="circle" coords="38,161,15" id ="412" title="previous" onclick="pressMenuRemote('412');">
-	<area shape="circle" coords="70,161,15" id ="11" title="0" onclick="pressMenuRemote('11');">
-	<area shape="circle" coords="102,161,15" id ="407" title="next" onclick="pressMenuRemote('407');">
-	<area shape="circle" coords="33,186,15" id ="398" title="red" onclick="pressMenuRemote('398');">
-	<area shape="circle" coords="58,186,15" id ="399" title="green" onclick="pressMenuRemote('399');">
-	<area shape="circle" coords="82,186,15" id ="400" title="yellow" onclick="pressMenuRemote('400');">
-	<area shape="circle" coords="105,186,15" id ="401" title="blue" onclick="pressMenuRemote('401');">
-	<area shape="circle" coords="70,213,15" id ="103" title="up" onclick="pressMenuRemote('103');">
-	<area shape="circle" coords="70,283,15" id ="108" title="down" onclick="pressMenuRemote('108');">
-	<area shape="circle" coords="35,248,15" id ="105" title="left" onclick="pressMenuRemote('105');">
-	<area shape="circle" coords="105,248,15" id ="106" title="right" onclick="pressMenuRemote('106');">
-	<area shape="circle" coords="70,248,20" id ="352" title="OK" onclick="pressMenuRemote('352');">
-	<area shape="circle" coords="40,307,15" id ="115" title="volume up" onclick="pressMenuRemote('115');">
-	<area shape="circle" coords="40,338,13" id ="114" title="volume down" onclick="pressMenuRemote('114');">
-	<area shape="circle" coords="70,310,15" id ="174" title="exit" onclick="pressMenuRemote('174');">
-	<area shape="circle" coords="70,334,15" id ="358" title="epg" onclick="pressMenuRemote('358');">
-	<area shape="circle" coords="99,307,15" id ="402" title="channelup" onclick="pressMenuRemote('402');">
-	<area shape="circle" coords="99,338,15" id ="403" title="channeldown" onclick="pressMenuRemote('403');">
-	<area shape="circle" coords="36,362,15" id ="139" title="menu" onclick="pressMenuRemote('139');">
-	<area shape="circle" coords="59,362,15" id ="393" title="videoaltlast" onclick="pressMenuRemote('393');">
-	<area shape="circle" coords="81,362,15" id ="392" title="audio" onclick="pressMenuRemote('392');">
-	<area shape="circle" coords="104,362,15" id ="138" title="help" onclick="pressMenuRemote('138');">
-	<area shape="circle" coords="36,383,15" id ="168" title="rewind" onclick="pressMenuRemote('168');">
-	<area shape="circle" coords="59,383,15" id ="207" title="play" onclick="pressMenuRemote('207');">
-	<area shape="circle" coords="81,383,15" id ="119" title="pause" onclick="pressMenuRemote('119');">
-	<area shape="circle" coords="104,383,15" id ="208" title="forward" onclick="pressMenuRemote('208');">
-	<area shape="circle" coords="36,405,15" id ="377" title="tv" onclick="pressMenuRemote('377');">
-	<area shape="circle" coords="59,405,15" id ="167" title="record" onclick="pressMenuRemote('167');">
-	<area shape="circle" coords="81,405,15" id ="128" title="stop" onclick="pressMenuRemote('128');">
-	<area shape="circle" coords="104,405,15" id ="385" title="radio" onclick="pressMenuRemote('385');">
+	<area shape="circle" coords="105,28,15" title="Power" onclick="pressMenuRemote('116');">
+	<area shape="circle" coords="33,53,15" title="text" onclick="pressMenuRemote('388');">
+	<area shape="circle" coords="58,53,15" title="subtitle" onclick="pressMenuRemote('370');">
+	<area shape="circle" coords="82,53,15" title="home" onclick="pressMenuRemote('102');">
+	<area shape="circle" coords="105,53,15" title="end" onclick="pressMenuRemote('107');">
+	<area shape="circle" coords="38,79,15" title="1" onclick="pressMenuRemote('2');">
+	<area shape="circle" coords="70,79,15" title="2" onclick="pressMenuRemote('3');">
+	<area shape="circle" coords="102,79,15" title="3" onclick="pressMenuRemote('4');">
+	<area shape="circle" coords="38,106,15" title="4" onclick="pressMenuRemote('5');">
+	<area shape="circle" coords="70,106,15" title="5" onclick="pressMenuRemote('6');">
+	<area shape="circle" coords="102,106,15" title="6" onclick="pressMenuRemote('7');">
+	<area shape="circle" coords="38,133,15" title="7" onclick="pressMenuRemote('8');">
+	<area shape="circle" coords="70,133,15" title="8" onclick="pressMenuRemote('9');">
+	<area shape="circle" coords="102,133,15" title="9" onclick="pressMenuRemote('10');">
+	<area shape="circle" coords="38,161,15" title="previous" onclick="pressMenuRemote('412');">
+	<area shape="circle" coords="70,161,15" title="0" onclick="pressMenuRemote('11');">
+	<area shape="circle" coords="102,161,15" title="next" onclick="pressMenuRemote('407');">
+	<area shape="circle" coords="33,186,15" title="red" onclick="pressMenuRemote('398');">
+	<area shape="circle" coords="58,186,15" title="green" onclick="pressMenuRemote('399');">
+	<area shape="circle" coords="82,186,15" title="yellow" onclick="pressMenuRemote('400');">
+	<area shape="circle" coords="105,186,15" title="blue" onclick="pressMenuRemote('401');">
+	<area shape="circle" coords="70,213,15" title="up" onclick="pressMenuRemote('103');">
+	<area shape="circle" coords="70,283,15" title="down" onclick="pressMenuRemote('108');">
+	<area shape="circle" coords="35,248,15" title="left" onclick="pressMenuRemote('105');">
+	<area shape="circle" coords="105,248,15" title="right" onclick="pressMenuRemote('106');">
+	<area shape="circle" coords="70,248,20" title="OK" onclick="pressMenuRemote('352');">
+	<area shape="circle" coords="40,307,15" title="volume up" onclick="pressMenuRemote('115');">
+	<area shape="circle" coords="40,338,13" title="volume down" onclick="pressMenuRemote('114');">
+	<area shape="circle" coords="70,310,15" title="exit" onclick="pressMenuRemote('174');">
+	<area shape="circle" coords="70,334,15" title="epg" onclick="pressMenuRemote('358');">
+	<area shape="circle" coords="99,307,15" title="channelup" onclick="pressMenuRemote('402');">
+	<area shape="circle" coords="99,338,15" title="channeldown" onclick="pressMenuRemote('403');">
+	<area shape="circle" coords="36,362,15" title="menu" onclick="pressMenuRemote('139');">
+	<area shape="circle" coords="59,362,15" title="videoaltlast" onclick="pressMenuRemote('393');">
+	<area shape="circle" coords="81,362,15" title="audio" onclick="pressMenuRemote('392');">
+	<area shape="circle" coords="104,362,15" title="help" onclick="pressMenuRemote('138');">
+	<area shape="circle" coords="36,383,15" title="rewind" onclick="pressMenuRemote('168');">
+	<area shape="circle" coords="59,383,15" title="play" onclick="pressMenuRemote('207');">
+	<area shape="circle" coords="81,383,15" title="pause" onclick="pressMenuRemote('119');">
+	<area shape="circle" coords="104,383,15" title="forward" onclick="pressMenuRemote('208');">
+	<area shape="circle" coords="36,405,15" title="tv" onclick="pressMenuRemote('377');">
+	<area shape="circle" coords="59,405,15" title="record" onclick="pressMenuRemote('167');">
+	<area shape="circle" coords="81,405,15" title="stop" onclick="pressMenuRemote('128');">
+	<area shape="circle" coords="104,405,15" title="radio" onclick="pressMenuRemote('385');">
 	-->

--- a/BoxBranding/remotes/vala/remote.html
+++ b/BoxBranding/remotes/vala/remote.html
@@ -1,40 +1,40 @@
 <img border='0' src='/static/remotes/vala/rc.png' usemap='#map' >
 <map name="map">
 	<area shape="rect" coords="14,19,39,33" title="mute" onclick="pressMenuRemote('113');">
-	<area shape="rect" coords="87,16,107,35" id ="116" title="Power" onclick="pressMenuRemote('116');">
-	<area shape="rect" coords="14,65,40,79" id ="388" title="text" onclick="pressMenuRemote('388');">
-	<area shape="rect" coords="47,66,73,79" id ="370" title="subtitle" onclick="pressMenuRemote('370');">
-	<area shape="rect" coords="47,44,74,59" id ="172" title="home" onclick="pressMenuRemote('172');">
-	<area shape="rect" coords="80,44,104,59" id ="107" title="end" onclick="pressMenuRemote('107');">
+	<area shape="rect" coords="87,16,107,35" title="Power" onclick="pressMenuRemote('116');">
+	<area shape="rect" coords="14,65,40,79" title="text" onclick="pressMenuRemote('388');">
+	<area shape="rect" coords="47,66,73,79" title="subtitle" onclick="pressMenuRemote('370');">
+	<area shape="rect" coords="47,44,74,59" title="home" onclick="pressMenuRemote('172');">
+	<area shape="rect" coords="80,44,104,59" title="end" onclick="pressMenuRemote('107');">
 
-	<area shape="rect" coords="13,258,40,279" id ="2" title="1" onclick="pressMenuRemote('2');">
-	<area shape="rect" coords="47,258,74,279" id ="3" title="2" onclick="pressMenuRemote('3');">
-	<area shape="rect" coords="81,258,109,279" id ="4" title="3" onclick="pressMenuRemote('4');">
-	<area shape="rect" coords="13,287,40,307" id ="5" title="4" onclick="pressMenuRemote('5');">
-	<area shape="rect" coords="47,287,74,307" id ="6" title="5" onclick="pressMenuRemote('6');">
-	<area shape="rect" coords="81,287,109,307" id ="7" title="6" onclick="pressMenuRemote('7');">
-	<area shape="rect" coords="13,315,40,337" id ="8" title="7" onclick="pressMenuRemote('8');">
-	<area shape="rect" coords="47,315,74,337" id ="9" title="8" onclick="pressMenuRemote('9');">
-	<area shape="rect" coords="81,315,109,337" id ="10" title="9" onclick="pressMenuRemote('10');">
-	<area shape="rect" coords="47,344,74,364" id ="11" title="0" onclick="pressMenuRemote('11');">
+	<area shape="rect" coords="13,258,40,279" title="1" onclick="pressMenuRemote('2');">
+	<area shape="rect" coords="47,258,74,279" title="2" onclick="pressMenuRemote('3');">
+	<area shape="rect" coords="81,258,109,279" title="3" onclick="pressMenuRemote('4');">
+	<area shape="rect" coords="13,287,40,307" title="4" onclick="pressMenuRemote('5');">
+	<area shape="rect" coords="47,287,74,307" title="5" onclick="pressMenuRemote('6');">
+	<area shape="rect" coords="81,287,109,307" title="6" onclick="pressMenuRemote('7');">
+	<area shape="rect" coords="13,315,40,337" title="7" onclick="pressMenuRemote('8');">
+	<area shape="rect" coords="47,315,74,337" title="8" onclick="pressMenuRemote('9');">
+	<area shape="rect" coords="81,315,109,337" title="9" onclick="pressMenuRemote('10');">
+	<area shape="rect" coords="47,344,74,364" title="0" onclick="pressMenuRemote('11');">
 
 	<!-- Added Key -->
 	<!--<area shape="rect" coords="96,95,118,107" title="Lan" onclick="pressMenuRemote(59);">-->
-	<area shape="circle" coords="98,179,10" id ="174" title="exit" onclick="pressMenuRemote('174');">
+	<area shape="circle" coords="98,179,10" title="exit" onclick="pressMenuRemote('174');">
 
-	<area shape="rect" coords="80,109,107,133" id ="402" title="channelup" onclick="pressMenuRemote('402');">
-	<area shape="rect" coords="80,137,107,162" id ="403" title="channeldown" onclick="pressMenuRemote('403');">
+	<area shape="rect" coords="80,109,107,133" title="channelup" onclick="pressMenuRemote('402');">
+	<area shape="rect" coords="80,137,107,162" title="channeldown" onclick="pressMenuRemote('403');">
 
-	<area shape="rect" coords="14,109,40,133" id ="115" title="volume up" onclick="pressMenuRemote('115');">
-	<area shape="rect" coords="14,137,40,162" id ="114" title="volume down" onclick="pressMenuRemote('114');">
+	<area shape="rect" coords="14,109,40,133" title="volume up" onclick="pressMenuRemote('115');">
+	<area shape="rect" coords="14,137,40,162" title="volume down" onclick="pressMenuRemote('114');">
 
-	<area shape="rect" coords="13,343,41,364" id ="412" title="previous" onclick="pressMenuRemote('412');">
-	<area shape="rect" coords="80,343,108,364" id ="407" title="next" onclick="pressMenuRemote('407');">
+	<area shape="rect" coords="13,343,41,364" title="previous" onclick="pressMenuRemote('412');">
+	<area shape="rect" coords="80,343,108,364" title="next" onclick="pressMenuRemote('407');">
 
-	<area shape="rect" coords="14,375,32,392" id ="398" title="red" onclick="pressMenuRemote('398');">
-	<area shape="rect" coords="38,375,57,392" id ="399" title="green" onclick="pressMenuRemote('399');">
-	<area shape="rect" coords="64,375,83,392" id ="400" title="yellow" onclick="pressMenuRemote('400');">
-	<area shape="rect" coords="89,375,108,392" id ="401" title="blue" onclick="pressMenuRemote('401');">
+	<area shape="rect" coords="14,375,32,392" title="red" onclick="pressMenuRemote('398');">
+	<area shape="rect" coords="38,375,57,392" title="green" onclick="pressMenuRemote('399');">
+	<area shape="rect" coords="64,375,83,392" title="yellow" onclick="pressMenuRemote('400');">
+	<area shape="rect" coords="89,375,108,392" title="blue" onclick="pressMenuRemote('401');">
 
 	<area shape="rect" coords="48,115,73,129" title="EPGPressed" onclick="pressMenuRemote(365);">
 	<area shape="circle" coords="22,244,10" title="openSatellites" onclick="pressMenuRemote(381);">
@@ -66,76 +66,76 @@
 
 	<!-- Rf modulator -->
 	<!--<area shape="rect" coords="98,114,116,124" title="showRFmod" onclick="pressMenuRemote(63);">-->
-	<area shape="circle" coords="99,244,10" id ="358" title="Info" onclick="pressMenuRemote('358');">
+	<area shape="circle" coords="99,244,10" title="Info" onclick="pressMenuRemote('358');">
 
-	<area shape="circle" coords="61,184,7" id ="103" title="up" onclick="pressMenuRemote('103');">
-	<area shape="circle" coords="61,238,7" id ="108" title="down" onclick="pressMenuRemote('108');">
-	<area shape="circle" coords="33,211,7" id ="105" title="left" onclick="pressMenuRemote('105');">
-	<area shape="circle" coords="86,211,7" id ="106" title="right" onclick="pressMenuRemote('106');">
+	<area shape="circle" coords="61,184,7" title="up" onclick="pressMenuRemote('103');">
+	<area shape="circle" coords="61,238,7" title="down" onclick="pressMenuRemote('108');">
+	<area shape="circle" coords="33,211,7" title="left" onclick="pressMenuRemote('105');">
+	<area shape="circle" coords="86,211,7" title="right" onclick="pressMenuRemote('106');">
 
-	<area shape="circle" coords="61,211,15" id ="352" title="OK" onclick="pressMenuRemote('352');">
-	<area shape="rect" coords="47,143,72,157" id ="392" title="audio" onclick="pressMenuRemote('392');">
+	<area shape="circle" coords="61,211,15" title="OK" onclick="pressMenuRemote('352');">
+	<area shape="rect" coords="47,143,72,157" title="audio" onclick="pressMenuRemote('392');">
 
-	<area shape="circle" coords="22,178,10" id ="139" title="menu" onclick="pressMenuRemote('139');">
-	<area shape="rect" coords="38,423,57,441" id ="167" title="record" onclick="pressMenuRemote('167');">
-	<area shape="rect" coords="13,86,40,100" id ="393" title="videoaltlast" onclick="pressMenuRemote('393');">
+	<area shape="circle" coords="22,178,10" title="menu" onclick="pressMenuRemote('139');">
+	<area shape="rect" coords="38,423,57,441" title="record" onclick="pressMenuRemote('167');">
+	<area shape="rect" coords="13,86,40,100" title="videoaltlast" onclick="pressMenuRemote('393');">
 
-	<area shape="rect" coords="13,44,40,59" id ="138" title="help" onclick="pressMenuRemote('138');">
+	<area shape="rect" coords="13,44,40,59" title="help" onclick="pressMenuRemote('138');">
 
-	<area shape="rect" coords="14,400,32,417" id ="168" title="rewind" onclick="pressMenuRemote('168');">
-	<area shape="rect" coords="38,400,58,417" id ="207" title="play" onclick="pressMenuRemote('207');">
-	<area shape="rect" coords="64,400,82,417" id ="119" title="pause" onclick="pressMenuRemote('119');">
-	<area shape="rect" coords="89,400,107,417" id ="208" title="forward" onclick="pressMenuRemote('208');">
-	<area shape="rect" coords="13,424,31,441" id ="377" title="tv" onclick="pressMenuRemote('377');">
+	<area shape="rect" coords="14,400,32,417" title="rewind" onclick="pressMenuRemote('168');">
+	<area shape="rect" coords="38,400,58,417" title="play" onclick="pressMenuRemote('207');">
+	<area shape="rect" coords="64,400,82,417" title="pause" onclick="pressMenuRemote('119');">
+	<area shape="rect" coords="89,400,107,417" title="forward" onclick="pressMenuRemote('208');">
+	<area shape="rect" coords="13,424,31,441" title="tv" onclick="pressMenuRemote('377');">
 
 
-	<area shape="rect" coords="63,424,82,440" id ="128" title="stop" onclick="pressMenuRemote('128');">
-	<area shape="circle" coords="90,424,107,440" id ="385" title="radio" onclick="pressMenuRemote('385');">
+	<area shape="rect" coords="63,424,82,440" title="stop" onclick="pressMenuRemote('128');">
+	<area shape="circle" coords="90,424,107,440" title="radio" onclick="pressMenuRemote('385');">
 </map>
 <!--
 	<area shape="circle" coords="33,28,15" title="mute" onclick="pressMenuRemote('113');">
-	<area shape="circle" coords="105,28,15" id ="116" title="Power" onclick="pressMenuRemote('116');">
-	<area shape="circle" coords="33,53,15" id ="388" title="text" onclick="pressMenuRemote('388');">
-	<area shape="circle" coords="58,53,15" id ="370" title="subtitle" onclick="pressMenuRemote('370');">
-	<area shape="circle" coords="82,53,15" id ="102" title="home" onclick="pressMenuRemote('102');">
-	<area shape="circle" coords="105,53,15" id ="107" title="end" onclick="pressMenuRemote('107');">
-	<area shape="circle" coords="38,79,15" id ="2" title="1" onclick="pressMenuRemote('2');">
-	<area shape="circle" coords="70,79,15" id ="3" title="2" onclick="pressMenuRemote('3');">
-	<area shape="circle" coords="102,79,15" id ="4" title="3" onclick="pressMenuRemote('4');">
-	<area shape="circle" coords="38,106,15" id ="5" title="4" onclick="pressMenuRemote('5');">
-	<area shape="circle" coords="70,106,15" id ="6" title="5" onclick="pressMenuRemote('6');">
-	<area shape="circle" coords="102,106,15" id ="7" title="6" onclick="pressMenuRemote('7');">
-	<area shape="circle" coords="38,133,15" id ="8" title="7" onclick="pressMenuRemote('8');">
-	<area shape="circle" coords="70,133,15" id ="9" title="8" onclick="pressMenuRemote('9');">
-	<area shape="circle" coords="102,133,15" id ="10" title="9" onclick="pressMenuRemote('10');">
-	<area shape="circle" coords="38,161,15" id ="412" title="previous" onclick="pressMenuRemote('412');">
-	<area shape="circle" coords="70,161,15" id ="11" title="0" onclick="pressMenuRemote('11');">
-	<area shape="circle" coords="102,161,15" id ="407" title="next" onclick="pressMenuRemote('407');">
-	<area shape="circle" coords="33,186,15" id ="398" title="red" onclick="pressMenuRemote('398');">
-	<area shape="circle" coords="58,186,15" id ="399" title="green" onclick="pressMenuRemote('399');">
-	<area shape="circle" coords="82,186,15" id ="400" title="yellow" onclick="pressMenuRemote('400');">
-	<area shape="circle" coords="105,186,15" id ="401" title="blue" onclick="pressMenuRemote('401');">
-	<area shape="circle" coords="70,213,15" id ="103" title="up" onclick="pressMenuRemote('103');">
-	<area shape="circle" coords="70,283,15" id ="108" title="down" onclick="pressMenuRemote('108');">
-	<area shape="circle" coords="35,248,15" id ="105" title="left" onclick="pressMenuRemote('105');">
-	<area shape="circle" coords="105,248,15" id ="106" title="right" onclick="pressMenuRemote('106');">
-	<area shape="circle" coords="70,248,20" id ="352" title="OK" onclick="pressMenuRemote('352');">
-	<area shape="circle" coords="40,307,15" id ="115" title="volume up" onclick="pressMenuRemote('115');">
-	<area shape="circle" coords="40,338,13" id ="114" title="volume down" onclick="pressMenuRemote('114');">
-	<area shape="circle" coords="70,310,15" id ="174" title="exit" onclick="pressMenuRemote('174');">
-	<area shape="circle" coords="70,334,15" id ="358" title="epg" onclick="pressMenuRemote('358');">
-	<area shape="circle" coords="99,307,15" id ="402" title="channelup" onclick="pressMenuRemote('402');">
-	<area shape="circle" coords="99,338,15" id ="403" title="channeldown" onclick="pressMenuRemote('403');">
-	<area shape="circle" coords="36,362,15" id ="139" title="menu" onclick="pressMenuRemote('139');">
-	<area shape="circle" coords="59,362,15" id ="393" title="videoaltlast" onclick="pressMenuRemote('393');">
-	<area shape="circle" coords="81,362,15" id ="392" title="audio" onclick="pressMenuRemote('392');">
-	<area shape="circle" coords="104,362,15" id ="138" title="help" onclick="pressMenuRemote('138');">
-	<area shape="circle" coords="36,383,15" id ="168" title="rewind" onclick="pressMenuRemote('168');">
-	<area shape="circle" coords="59,383,15" id ="207" title="play" onclick="pressMenuRemote('207');">
-	<area shape="circle" coords="81,383,15" id ="119" title="pause" onclick="pressMenuRemote('119');">
-	<area shape="circle" coords="104,383,15" id ="208" title="forward" onclick="pressMenuRemote('208');">
-	<area shape="circle" coords="36,405,15" id ="377" title="tv" onclick="pressMenuRemote('377');">
-	<area shape="circle" coords="59,405,15" id ="167" title="record" onclick="pressMenuRemote('167');">
-	<area shape="circle" coords="81,405,15" id ="128" title="stop" onclick="pressMenuRemote('128');">
-	<area shape="circle" coords="104,405,15" id ="385" title="radio" onclick="pressMenuRemote('385');">
+	<area shape="circle" coords="105,28,15" title="Power" onclick="pressMenuRemote('116');">
+	<area shape="circle" coords="33,53,15" title="text" onclick="pressMenuRemote('388');">
+	<area shape="circle" coords="58,53,15" title="subtitle" onclick="pressMenuRemote('370');">
+	<area shape="circle" coords="82,53,15" title="home" onclick="pressMenuRemote('102');">
+	<area shape="circle" coords="105,53,15" title="end" onclick="pressMenuRemote('107');">
+	<area shape="circle" coords="38,79,15" title="1" onclick="pressMenuRemote('2');">
+	<area shape="circle" coords="70,79,15" title="2" onclick="pressMenuRemote('3');">
+	<area shape="circle" coords="102,79,15" title="3" onclick="pressMenuRemote('4');">
+	<area shape="circle" coords="38,106,15" title="4" onclick="pressMenuRemote('5');">
+	<area shape="circle" coords="70,106,15" title="5" onclick="pressMenuRemote('6');">
+	<area shape="circle" coords="102,106,15" title="6" onclick="pressMenuRemote('7');">
+	<area shape="circle" coords="38,133,15" title="7" onclick="pressMenuRemote('8');">
+	<area shape="circle" coords="70,133,15" title="8" onclick="pressMenuRemote('9');">
+	<area shape="circle" coords="102,133,15" title="9" onclick="pressMenuRemote('10');">
+	<area shape="circle" coords="38,161,15" title="previous" onclick="pressMenuRemote('412');">
+	<area shape="circle" coords="70,161,15" title="0" onclick="pressMenuRemote('11');">
+	<area shape="circle" coords="102,161,15" title="next" onclick="pressMenuRemote('407');">
+	<area shape="circle" coords="33,186,15" title="red" onclick="pressMenuRemote('398');">
+	<area shape="circle" coords="58,186,15" title="green" onclick="pressMenuRemote('399');">
+	<area shape="circle" coords="82,186,15" title="yellow" onclick="pressMenuRemote('400');">
+	<area shape="circle" coords="105,186,15" title="blue" onclick="pressMenuRemote('401');">
+	<area shape="circle" coords="70,213,15" title="up" onclick="pressMenuRemote('103');">
+	<area shape="circle" coords="70,283,15" title="down" onclick="pressMenuRemote('108');">
+	<area shape="circle" coords="35,248,15" title="left" onclick="pressMenuRemote('105');">
+	<area shape="circle" coords="105,248,15" title="right" onclick="pressMenuRemote('106');">
+	<area shape="circle" coords="70,248,20" title="OK" onclick="pressMenuRemote('352');">
+	<area shape="circle" coords="40,307,15" title="volume up" onclick="pressMenuRemote('115');">
+	<area shape="circle" coords="40,338,13" title="volume down" onclick="pressMenuRemote('114');">
+	<area shape="circle" coords="70,310,15" title="exit" onclick="pressMenuRemote('174');">
+	<area shape="circle" coords="70,334,15" title="epg" onclick="pressMenuRemote('358');">
+	<area shape="circle" coords="99,307,15" title="channelup" onclick="pressMenuRemote('402');">
+	<area shape="circle" coords="99,338,15" title="channeldown" onclick="pressMenuRemote('403');">
+	<area shape="circle" coords="36,362,15" title="menu" onclick="pressMenuRemote('139');">
+	<area shape="circle" coords="59,362,15" title="videoaltlast" onclick="pressMenuRemote('393');">
+	<area shape="circle" coords="81,362,15" title="audio" onclick="pressMenuRemote('392');">
+	<area shape="circle" coords="104,362,15" title="help" onclick="pressMenuRemote('138');">
+	<area shape="circle" coords="36,383,15" title="rewind" onclick="pressMenuRemote('168');">
+	<area shape="circle" coords="59,383,15" title="play" onclick="pressMenuRemote('207');">
+	<area shape="circle" coords="81,383,15" title="pause" onclick="pressMenuRemote('119');">
+	<area shape="circle" coords="104,383,15" title="forward" onclick="pressMenuRemote('208');">
+	<area shape="circle" coords="36,405,15" title="tv" onclick="pressMenuRemote('377');">
+	<area shape="circle" coords="59,405,15" title="record" onclick="pressMenuRemote('167');">
+	<area shape="circle" coords="81,405,15" title="stop" onclick="pressMenuRemote('128');">
+	<area shape="circle" coords="104,405,15" title="radio" onclick="pressMenuRemote('385');">
 	-->

--- a/BoxBranding/remotes/vu/remote.html
+++ b/BoxBranding/remotes/vu/remote.html
@@ -1,48 +1,48 @@
 <img border='0' src='/static/remotes/vu/rc.png' usemap='#map' >
 <map name="map">
 	<area shape="circle" coords="33,28,15" title="mute" onclick="pressMenuRemote('113');">
-	<area shape="circle" coords="105,28,15" id ="116" title="Power" onclick="pressMenuRemote('116');">
-	<area shape="circle" coords="33,53,15" id ="388" title="text" onclick="pressMenuRemote('388');">
-	<area shape="circle" coords="58,53,15" id ="370" title="subtitle" onclick="pressMenuRemote('370');">
-	<area shape="circle" coords="82,53,15" id ="102" title="home" onclick="pressMenuRemote('102');">
-	<area shape="circle" coords="105,53,15" id ="107" title="end" onclick="pressMenuRemote('107');">
-	<area shape="circle" coords="38,79,15" id ="2" title="1" onclick="pressMenuRemote('2');">
-	<area shape="circle" coords="70,79,15" id ="3" title="2" onclick="pressMenuRemote('3');">
-	<area shape="circle" coords="102,79,15" id ="4" title="3" onclick="pressMenuRemote('4');">
-	<area shape="circle" coords="38,106,15" id ="5" title="4" onclick="pressMenuRemote('5');">
-	<area shape="circle" coords="70,106,15" id ="6" title="5" onclick="pressMenuRemote('6');">
-	<area shape="circle" coords="102,106,15" id ="7" title="6" onclick="pressMenuRemote('7');">
-	<area shape="circle" coords="38,133,15" id ="8" title="7" onclick="pressMenuRemote('8');">
-	<area shape="circle" coords="70,133,15" id ="9" title="8" onclick="pressMenuRemote('9');">
-	<area shape="circle" coords="102,133,15" id ="10" title="9" onclick="pressMenuRemote('10');">
-	<area shape="circle" coords="38,161,15" id ="412" title="previous" onclick="pressMenuRemote('412');">
-	<area shape="circle" coords="70,161,15" id ="11" title="0" onclick="pressMenuRemote('11');">
-	<area shape="circle" coords="102,161,15" id ="407" title="next" onclick="pressMenuRemote('407');">
-	<area shape="circle" coords="33,186,15" id ="398" title="red" onclick="pressMenuRemote('398');">
-	<area shape="circle" coords="58,186,15" id ="399" title="green" onclick="pressMenuRemote('399');">
-	<area shape="circle" coords="82,186,15" id ="400" title="yellow" onclick="pressMenuRemote('400');">
-	<area shape="circle" coords="105,186,15" id ="401" title="blue" onclick="pressMenuRemote('401');">
-	<area shape="circle" coords="70,213,15" id ="103" title="up" onclick="pressMenuRemote('103');">
-	<area shape="circle" coords="70,283,15" id ="108" title="down" onclick="pressMenuRemote('108');">
-	<area shape="circle" coords="35,248,15" id ="105" title="left" onclick="pressMenuRemote('105');">
-	<area shape="circle" coords="105,248,15" id ="106" title="right" onclick="pressMenuRemote('106');">
-	<area shape="circle" coords="70,248,20" id ="352" title="OK" onclick="pressMenuRemote('352');">
-	<area shape="circle" coords="40,307,15" id ="115" title="volume up" onclick="pressMenuRemote('115');">
-	<area shape="circle" coords="40,338,13" id ="114" title="volume down" onclick="pressMenuRemote('114');">
-	<area shape="circle" coords="70,310,15" id ="174" title="exit" onclick="pressMenuRemote('174');">
-	<area shape="circle" coords="70,334,15" id ="358" title="epg" onclick="pressMenuRemote('358');">
-	<area shape="circle" coords="99,307,15" id ="402" title="channelup" onclick="pressMenuRemote('402');">
-	<area shape="circle" coords="99,338,15" id ="403" title="channeldown" onclick="pressMenuRemote('403');">
-	<area shape="circle" coords="36,362,15" id ="139" title="menu" onclick="pressMenuRemote('139');">
-	<area shape="circle" coords="59,362,15" id ="393" title="videoaltlast" onclick="pressMenuRemote('393');">
-	<area shape="circle" coords="81,362,15" id ="392" title="audio" onclick="pressMenuRemote('392');">
-	<area shape="circle" coords="104,362,15" id ="138" title="help" onclick="pressMenuRemote('138');">
-	<area shape="circle" coords="36,383,15" id ="168" title="rewind" onclick="pressMenuRemote('168');">
-	<area shape="circle" coords="59,383,15" id ="207" title="play" onclick="pressMenuRemote('207');">
-	<area shape="circle" coords="81,383,15" id ="119" title="pause" onclick="pressMenuRemote('119');">
-	<area shape="circle" coords="104,383,15" id ="208" title="forward" onclick="pressMenuRemote('208');">
-	<area shape="circle" coords="36,405,15" id ="377" title="tv" onclick="pressMenuRemote('377');">
-	<area shape="circle" coords="59,405,15" id ="167" title="record" onclick="pressMenuRemote('167');">
-	<area shape="circle" coords="81,405,15" id ="128" title="stop" onclick="pressMenuRemote('128');">
-	<area shape="circle" coords="104,405,15" id ="385" title="radio" onclick="pressMenuRemote('385');">
+	<area shape="circle" coords="105,28,15" title="Power" onclick="pressMenuRemote('116');">
+	<area shape="circle" coords="33,53,15" title="text" onclick="pressMenuRemote('388');">
+	<area shape="circle" coords="58,53,15" title="subtitle" onclick="pressMenuRemote('370');">
+	<area shape="circle" coords="82,53,15" title="home" onclick="pressMenuRemote('102');">
+	<area shape="circle" coords="105,53,15" title="end" onclick="pressMenuRemote('107');">
+	<area shape="circle" coords="38,79,15" title="1" onclick="pressMenuRemote('2');">
+	<area shape="circle" coords="70,79,15" title="2" onclick="pressMenuRemote('3');">
+	<area shape="circle" coords="102,79,15" title="3" onclick="pressMenuRemote('4');">
+	<area shape="circle" coords="38,106,15" title="4" onclick="pressMenuRemote('5');">
+	<area shape="circle" coords="70,106,15" title="5" onclick="pressMenuRemote('6');">
+	<area shape="circle" coords="102,106,15" title="6" onclick="pressMenuRemote('7');">
+	<area shape="circle" coords="38,133,15" title="7" onclick="pressMenuRemote('8');">
+	<area shape="circle" coords="70,133,15" title="8" onclick="pressMenuRemote('9');">
+	<area shape="circle" coords="102,133,15" title="9" onclick="pressMenuRemote('10');">
+	<area shape="circle" coords="38,161,15" title="previous" onclick="pressMenuRemote('412');">
+	<area shape="circle" coords="70,161,15" title="0" onclick="pressMenuRemote('11');">
+	<area shape="circle" coords="102,161,15" title="next" onclick="pressMenuRemote('407');">
+	<area shape="circle" coords="33,186,15" title="red" onclick="pressMenuRemote('398');">
+	<area shape="circle" coords="58,186,15" title="green" onclick="pressMenuRemote('399');">
+	<area shape="circle" coords="82,186,15" title="yellow" onclick="pressMenuRemote('400');">
+	<area shape="circle" coords="105,186,15" title="blue" onclick="pressMenuRemote('401');">
+	<area shape="circle" coords="70,213,15" title="up" onclick="pressMenuRemote('103');">
+	<area shape="circle" coords="70,283,15" title="down" onclick="pressMenuRemote('108');">
+	<area shape="circle" coords="35,248,15" title="left" onclick="pressMenuRemote('105');">
+	<area shape="circle" coords="105,248,15" title="right" onclick="pressMenuRemote('106');">
+	<area shape="circle" coords="70,248,20" title="OK" onclick="pressMenuRemote('352');">
+	<area shape="circle" coords="40,307,15" title="volume up" onclick="pressMenuRemote('115');">
+	<area shape="circle" coords="40,338,13" title="volume down" onclick="pressMenuRemote('114');">
+	<area shape="circle" coords="70,310,15" title="exit" onclick="pressMenuRemote('174');">
+	<area shape="circle" coords="70,334,15" title="epg" onclick="pressMenuRemote('358');">
+	<area shape="circle" coords="99,307,15" title="channelup" onclick="pressMenuRemote('402');">
+	<area shape="circle" coords="99,338,15" title="channeldown" onclick="pressMenuRemote('403');">
+	<area shape="circle" coords="36,362,15" title="menu" onclick="pressMenuRemote('139');">
+	<area shape="circle" coords="59,362,15" title="videoaltlast" onclick="pressMenuRemote('393');">
+	<area shape="circle" coords="81,362,15" title="audio" onclick="pressMenuRemote('392');">
+	<area shape="circle" coords="104,362,15" title="help" onclick="pressMenuRemote('138');">
+	<area shape="circle" coords="36,383,15" title="rewind" onclick="pressMenuRemote('168');">
+	<area shape="circle" coords="59,383,15" title="play" onclick="pressMenuRemote('207');">
+	<area shape="circle" coords="81,383,15" title="pause" onclick="pressMenuRemote('119');">
+	<area shape="circle" coords="104,383,15" title="forward" onclick="pressMenuRemote('208');">
+	<area shape="circle" coords="36,405,15" title="tv" onclick="pressMenuRemote('377');">
+	<area shape="circle" coords="59,405,15" title="record" onclick="pressMenuRemote('167');">
+	<area shape="circle" coords="81,405,15" title="stop" onclick="pressMenuRemote('128');">
+	<area shape="circle" coords="104,405,15" title="radio" onclick="pressMenuRemote('385');">
 </map>

--- a/BoxBranding/remotes/vu3/remote.html
+++ b/BoxBranding/remotes/vu3/remote.html
@@ -1,45 +1,45 @@
 <img border='0' src='/static/remotes/vu3/rc.png' usemap='#map' >
 <map name="map">
 	<area shape="circle" coords="77,53,15" title="mute" onclick="pressMenuRemote('113');">
-	<area shape="circle" coords="114,49,15" id ="116" title="Power" onclick="pressMenuRemote('116');">
-	<area shape="circle" coords="39,160,15" id ="388" title="text" onclick="pressMenuRemote('388');">
-	<area shape="circle" coords="39,337,15" id ="2" title="1" onclick="pressMenuRemote('2');">
-	<area shape="circle" coords="77 ,337,15" id ="3" title="2" onclick="pressMenuRemote('3');">
-	<area shape="circle" coords="112,337,15" id ="4" title="3" onclick="pressMenuRemote('4');">
-	<area shape="circle" coords="39,357,15" id ="5" title="4" onclick="pressMenuRemote('5');">
-	<area shape="circle" coords="77,357,15" id ="6" title="5" onclick="pressMenuRemote('6');">
-	<area shape="circle" coords="112,357,15" id ="7" title="6" onclick="pressMenuRemote('7');">
-	<area shape="circle" coords="39,377,15" id ="8" title="7" onclick="pressMenuRemote('8');">
-	<area shape="circle" coords="77,377,15" id ="9" title="8" onclick="pressMenuRemote('9');">
-	<area shape="circle" coords="112,377,15" id ="10" title="9" onclick="pressMenuRemote('10');">
-	<area shape="circle" coords="77,397,15" id ="11" title="0" onclick="pressMenuRemote('11');">
-	<area shape="circle" coords="43,399,15" id ="412" title="previous" onclick="pressMenuRemote('412');">
-	<area shape="circle" coords="112,399,15" id ="407" title="next" onclick="pressMenuRemote('407');">
-	<area shape="circle" coords="36,316,15" id ="398" title="red" onclick="pressMenuRemote('398');">
-	<area shape="circle" coords="64,316,15" id ="399" title="green" onclick="pressMenuRemote('399');">
-	<area shape="circle" coords="92,316,15" id ="400" title="yellow" onclick="pressMenuRemote('400');">
-	<area shape="circle" coords="120,316,15" id ="401" title="blue" onclick="pressMenuRemote('401');">
-	<area shape="circle" coords="75,224,15" id ="103" title="up" onclick="pressMenuRemote('103');">
-	<area shape="circle" coords="75,274,15" id ="108" title="down" onclick="pressMenuRemote('108');">
-	<area shape="circle" coords="50,250,15" id ="105" title="left" onclick="pressMenuRemote('105');">
-	<area shape="circle" coords="100,250,15" id ="106" title="right" onclick="pressMenuRemote('106');">
-	<area shape="circle" coords="75,250,20" id ="352" title="OK" onclick="pressMenuRemote('352');">
-	<area shape="circle" coords="33,212,15" id ="115" title="volume up" onclick="pressMenuRemote('115');">
-	<area shape="circle" coords="33,285,13" id ="114" title="volume down" onclick="pressMenuRemote('114');">
-	<area shape="circle" coords="114,180,15" id ="174" title="exit" onclick="pressMenuRemote('174');">
-	<area shape="circle" coords="40,180,15" id ="358" title="epg" onclick="pressMenuRemote('358');">
-	<area shape="circle" coords="119,213,15" id ="402" title="channelup" onclick="pressMenuRemote('402');">
-	<area shape="circle" coords="119,285,15" id ="403" title="channeldown" onclick="pressMenuRemote('403');">
-	<area shape="circle" coords="77,180,15" id ="139" title="menu" onclick="pressMenuRemote('139');">
-	<area shape="circle" coords="112,117,15" id ="393" title="videoaltlast" onclick="pressMenuRemote('393');">
-	<area shape="circle" coords="77,141,15" id ="392" title="audio" onclick="pressMenuRemote('392');">
-	<area shape="circle" coords="77,159,15" id ="138" title="help" onclick="pressMenuRemote('138');">
-	<area shape="circle" coords="42,94,15" id ="168" title="rewind" onclick="pressMenuRemote('168');">
-	<area shape="circle" coords="77,94,15" id ="207" title="play" onclick="pressMenuRemote('207');">
-	<area shape="circle" coords="77,94,15" id ="119" title="pause" onclick="pressMenuRemote('119');">
-	<area shape="circle" coords="112,94,15" id ="208" title="forward" onclick="pressMenuRemote('208');">
-	<area shape="circle" coords="42,140,15" id ="377" title="tv" onclick="pressMenuRemote('377');">
-	<area shape="circle" coords="42,115,15" id ="167" title="record" onclick="pressMenuRemote('167');">
-	<area shape="circle" coords="77,115,15" id ="128" title="stop" onclick="pressMenuRemote('128');">
-	<area shape="circle" coords="114,140,15" id ="385" title="radio" onclick="pressMenuRemote('385');">
+	<area shape="circle" coords="114,49,15" title="Power" onclick="pressMenuRemote('116');">
+	<area shape="circle" coords="39,160,15" title="text" onclick="pressMenuRemote('388');">
+	<area shape="circle" coords="39,337,15" title="1" onclick="pressMenuRemote('2');">
+	<area shape="circle" coords="77 ,337,15" title="2" onclick="pressMenuRemote('3');">
+	<area shape="circle" coords="112,337,15" title="3" onclick="pressMenuRemote('4');">
+	<area shape="circle" coords="39,357,15" title="4" onclick="pressMenuRemote('5');">
+	<area shape="circle" coords="77,357,15" title="5" onclick="pressMenuRemote('6');">
+	<area shape="circle" coords="112,357,15" title="6" onclick="pressMenuRemote('7');">
+	<area shape="circle" coords="39,377,15" title="7" onclick="pressMenuRemote('8');">
+	<area shape="circle" coords="77,377,15" title="8" onclick="pressMenuRemote('9');">
+	<area shape="circle" coords="112,377,15" title="9" onclick="pressMenuRemote('10');">
+	<area shape="circle" coords="77,397,15" title="0" onclick="pressMenuRemote('11');">
+	<area shape="circle" coords="43,399,15" title="previous" onclick="pressMenuRemote('412');">
+	<area shape="circle" coords="112,399,15" title="next" onclick="pressMenuRemote('407');">
+	<area shape="circle" coords="36,316,15" title="red" onclick="pressMenuRemote('398');">
+	<area shape="circle" coords="64,316,15" title="green" onclick="pressMenuRemote('399');">
+	<area shape="circle" coords="92,316,15" title="yellow" onclick="pressMenuRemote('400');">
+	<area shape="circle" coords="120,316,15" title="blue" onclick="pressMenuRemote('401');">
+	<area shape="circle" coords="75,224,15" title="up" onclick="pressMenuRemote('103');">
+	<area shape="circle" coords="75,274,15" title="down" onclick="pressMenuRemote('108');">
+	<area shape="circle" coords="50,250,15" title="left" onclick="pressMenuRemote('105');">
+	<area shape="circle" coords="100,250,15" title="right" onclick="pressMenuRemote('106');">
+	<area shape="circle" coords="75,250,20" title="OK" onclick="pressMenuRemote('352');">
+	<area shape="circle" coords="33,212,15" title="volume up" onclick="pressMenuRemote('115');">
+	<area shape="circle" coords="33,285,13" title="volume down" onclick="pressMenuRemote('114');">
+	<area shape="circle" coords="114,180,15" title="exit" onclick="pressMenuRemote('174');">
+	<area shape="circle" coords="40,180,15" title="epg" onclick="pressMenuRemote('358');">
+	<area shape="circle" coords="119,213,15" title="channelup" onclick="pressMenuRemote('402');">
+	<area shape="circle" coords="119,285,15" title="channeldown" onclick="pressMenuRemote('403');">
+	<area shape="circle" coords="77,180,15" title="menu" onclick="pressMenuRemote('139');">
+	<area shape="circle" coords="112,117,15" title="videoaltlast" onclick="pressMenuRemote('393');">
+	<area shape="circle" coords="77,141,15" title="audio" onclick="pressMenuRemote('392');">
+	<area shape="circle" coords="77,159,15" title="help" onclick="pressMenuRemote('138');">
+	<area shape="circle" coords="42,94,15" title="rewind" onclick="pressMenuRemote('168');">
+	<area shape="circle" coords="77,94,15" title="play" onclick="pressMenuRemote('207');">
+	<area shape="circle" coords="77,94,15" title="pause" onclick="pressMenuRemote('119');">
+	<area shape="circle" coords="112,94,15" title="forward" onclick="pressMenuRemote('208');">
+	<area shape="circle" coords="42,140,15" title="tv" onclick="pressMenuRemote('377');">
+	<area shape="circle" coords="42,115,15" title="record" onclick="pressMenuRemote('167');">
+	<area shape="circle" coords="77,115,15" title="stop" onclick="pressMenuRemote('128');">
+	<area shape="circle" coords="114,140,15" title="radio" onclick="pressMenuRemote('385');">
 </map>

--- a/BoxBranding/remotes/vu4/remote.html
+++ b/BoxBranding/remotes/vu4/remote.html
@@ -1,47 +1,47 @@
 <img border='0' src='/static/remotes/vu4/rc.png' usemap='#map' >
 <map name="map">
-	<area shape="rect" coords="95,17,118,30" id ="116" title="Power" onclick="pressMenuRemote('116');">
-	<area shape="rect" coords="21,40,41,50" id ="388" title="text" onclick="pressMenuRemote('388');">
-	<area shape="rect" coords="47,40,67,50" id ="370" title="subtitle" onclick="pressMenuRemote('370');">
-	<area shape="rect" coords="21,60,50,70" id ="2" title="1" onclick="pressMenuRemote('2');">
-	<area shape="rect" coords="56,60,85,70" id ="3" title="2" onclick="pressMenuRemote('3');">
-	<area shape="rect" coords="91,60,120,70" id ="4" title="3" onclick="pressMenuRemote('4');">
-	<area shape="rect" coords="21,80,50,90" id ="5" title="4" onclick="pressMenuRemote('5');">
-	<area shape="rect" coords="56,80,85,90" id ="6" title="5" onclick="pressMenuRemote('6');">
-	<area shape="rect" coords="91,80,120,90" id ="7" title="6" onclick="pressMenuRemote('7');">
-	<area shape="rect" coords="21,101,50,111" id ="8" title="7" onclick="pressMenuRemote('8');">
-	<area shape="rect" coords="56,101,85,111" id ="9" title="8" onclick="pressMenuRemote('9');">
-	<area shape="rect" coords="91,101,120,111" id ="10" title="9" onclick="pressMenuRemote('10');">
-	<area shape="rect" coords="21,121,50,131" id ="412" title="previous" onclick="pressMenuRemote('412');">
-	<area shape="rect" coords="56,121,85,131" id ="11" title="0" onclick="pressMenuRemote('11');">
-	<area shape="rect" coords="91,121,120,131" id ="407" title="next" onclick="pressMenuRemote('407');">
-	<area shape="rect" coords="21,144,41,153" id ="398" title="red" onclick="pressMenuRemote('398');">
-	<area shape="rect" coords="47,144,67,153" id ="399" title="green" onclick="pressMenuRemote('399');">
-	<area shape="rect" coords="74,144,94,153" id ="400" title="yellow" onclick="pressMenuRemote('400');">
-	<area shape="rect" coords="99,144,119,153" id ="401" title="blue" onclick="pressMenuRemote('401');">
-	<area shape="rect" coords="58,167,83,182" id ="103" title="up" onclick="pressMenuRemote('103');">
-	<area shape="rect" coords="58,221,83,236" id ="108" title="down" onclick="pressMenuRemote('108');">
-	<area shape="rect" coords="39,189,51,211" id ="105" title="left" onclick="pressMenuRemote('105');">
-	<area shape="rect" coords="89,189,101,211" id ="106" title="right" onclick="pressMenuRemote('106');">
-	<area shape="circle" coords="70,200,34" id ="352" title="OK" onclick="pressMenuRemote('352');">
-	<area shape="rect" coords="21,249,50,274" id ="115" title="volume up" onclick="pressMenuRemote('115');">
-	<area shape="rect" coords="21,275,50,300" id ="114" title="volume down" onclick="pressMenuRemote('114');">
-	<area shape="rect" coords="91,226,118,236" id ="174" title="exit" onclick="pressMenuRemote('174');">
-	<area shape="rect" coords="21,226,48,236" id ="358" title="epg" onclick="pressMenuRemote('358');">
-	<area shape="rect" coords="90,249,119,274" id ="402" title="channelup" onclick="pressMenuRemote('402');">
-	<area shape="rect" coords="90,275,119,300" id ="403" title="channeldown" onclick="pressMenuRemote('403');">
-	<area shape="rect" coords="91,165,118,236," id ="139" title="menu" onclick="pressMenuRemote('139');">
-	<area shape="rect" coords="21,165,48,236" id ="393" title="videolist" onclick="pressMenuRemote('393');">
-	<area shape="rect" coords="60,249,80,260" id ="392" title="audio" onclick="pressMenuRemote('392');">
+	<area shape="rect" coords="95,17,118,30" title="Power" onclick="pressMenuRemote('116');">
+	<area shape="rect" coords="21,40,41,50" title="text" onclick="pressMenuRemote('388');">
+	<area shape="rect" coords="47,40,67,50" title="subtitle" onclick="pressMenuRemote('370');">
+	<area shape="rect" coords="21,60,50,70" title="1" onclick="pressMenuRemote('2');">
+	<area shape="rect" coords="56,60,85,70" title="2" onclick="pressMenuRemote('3');">
+	<area shape="rect" coords="91,60,120,70" title="3" onclick="pressMenuRemote('4');">
+	<area shape="rect" coords="21,80,50,90" title="4" onclick="pressMenuRemote('5');">
+	<area shape="rect" coords="56,80,85,90" title="5" onclick="pressMenuRemote('6');">
+	<area shape="rect" coords="91,80,120,90" title="6" onclick="pressMenuRemote('7');">
+	<area shape="rect" coords="21,101,50,111" title="7" onclick="pressMenuRemote('8');">
+	<area shape="rect" coords="56,101,85,111" title="8" onclick="pressMenuRemote('9');">
+	<area shape="rect" coords="91,101,120,111" title="9" onclick="pressMenuRemote('10');">
+	<area shape="rect" coords="21,121,50,131" title="previous" onclick="pressMenuRemote('412');">
+	<area shape="rect" coords="56,121,85,131" title="0" onclick="pressMenuRemote('11');">
+	<area shape="rect" coords="91,121,120,131" title="next" onclick="pressMenuRemote('407');">
+	<area shape="rect" coords="21,144,41,153" title="red" onclick="pressMenuRemote('398');">
+	<area shape="rect" coords="47,144,67,153" title="green" onclick="pressMenuRemote('399');">
+	<area shape="rect" coords="74,144,94,153" title="yellow" onclick="pressMenuRemote('400');">
+	<area shape="rect" coords="99,144,119,153" title="blue" onclick="pressMenuRemote('401');">
+	<area shape="rect" coords="58,167,83,182" title="up" onclick="pressMenuRemote('103');">
+	<area shape="rect" coords="58,221,83,236" title="down" onclick="pressMenuRemote('108');">
+	<area shape="rect" coords="39,189,51,211" title="left" onclick="pressMenuRemote('105');">
+	<area shape="rect" coords="89,189,101,211" title="right" onclick="pressMenuRemote('106');">
+	<area shape="circle" coords="70,200,34" title="OK" onclick="pressMenuRemote('352');">
+	<area shape="rect" coords="21,249,50,274" title="volume up" onclick="pressMenuRemote('115');">
+	<area shape="rect" coords="21,275,50,300" title="volume down" onclick="pressMenuRemote('114');">
+	<area shape="rect" coords="91,226,118,236" title="exit" onclick="pressMenuRemote('174');">
+	<area shape="rect" coords="21,226,48,236" title="epg" onclick="pressMenuRemote('358');">
+	<area shape="rect" coords="90,249,119,274" title="channelup" onclick="pressMenuRemote('402');">
+	<area shape="rect" coords="90,275,119,300" title="channeldown" onclick="pressMenuRemote('403');">
+	<area shape="rect" coords="91,165,118,236," title="menu" onclick="pressMenuRemote('139');">
+	<area shape="rect" coords="21,165,48,236" title="videolist" onclick="pressMenuRemote('393');">
+	<area shape="rect" coords="60,249,80,260" title="audio" onclick="pressMenuRemote('392');">
 	<area shape="rect" coords="60,269,80,280" title="mute" onclick="pressMenuRemote('113');">
-	<area shape="rect" coords="60,290,80,301" id ="176" title="timer edit" onclick="pressMenuRemote('176');">
-	<area shape="rect" coords="100,40,120,50" id ="138" title="help" onclick="pressMenuRemote('138');">
-	<area shape="rect" coords="21,309,41,319" id ="168" title="rewind" onclick="pressMenuRemote('168');">
-	<area shape="rect" coords="47,309,67,319" id ="207" title="play" onclick="pressMenuRemote('207');">
-	<area shape="rect" coords="73,309,93,319" id ="119" title="pause" onclick="pressMenuRemote('119');">
-	<area shape="rect" coords="100,309,120,319" id ="208" title="forward" onclick="pressMenuRemote('208');">
-	<area shape="rect" coords="21,328,41,338" id ="377" title="tv" onclick="pressMenuRemote('377');">
-	<area shape="rect" coords="47,328,67,338" id ="167" title="record" onclick="pressMenuRemote('167');">
-	<area shape="rect" coords="73,328,93,338" id ="128" title="stop" onclick="pressMenuRemote('128');">
-	<area shape="rect" coords="100.328.120.338" id ="385" title="radio" onclick="pressMenuRemote('385');">
+	<area shape="rect" coords="60,290,80,301" title="timer edit" onclick="pressMenuRemote('176');">
+	<area shape="rect" coords="100,40,120,50" title="help" onclick="pressMenuRemote('138');">
+	<area shape="rect" coords="21,309,41,319" title="rewind" onclick="pressMenuRemote('168');">
+	<area shape="rect" coords="47,309,67,319" title="play" onclick="pressMenuRemote('207');">
+	<area shape="rect" coords="73,309,93,319" title="pause" onclick="pressMenuRemote('119');">
+	<area shape="rect" coords="100,309,120,319" title="forward" onclick="pressMenuRemote('208');">
+	<area shape="rect" coords="21,328,41,338" title="tv" onclick="pressMenuRemote('377');">
+	<area shape="rect" coords="47,328,67,338" title="record" onclick="pressMenuRemote('167');">
+	<area shape="rect" coords="73,328,93,338" title="stop" onclick="pressMenuRemote('128');">
+	<area shape="rect" coords="100.328.120.338" title="radio" onclick="pressMenuRemote('385');">
 </map>


### PR DESCRIPTION
The previous commit missed id attributes with whits space in then,
like "id =".

This commit removes id attributes from a further 28 remmotes.

Thanks to persianpros for finding the id atributes that weren't
removed by the previous commit.