### PR TITLE
[vu] Fix CH- & VOL-

### DIFF
--- a/BoxBranding/remotes/vu/rcpositions.xml
+++ b/BoxBranding/remotes/vu/rcpositions.xml
@@ -29,8 +29,8 @@
 		<button name="BOUQUET+" pos="105,316" />
 		<button name="EXIT" pos="70,318" />
 		<button name="INFO" pos="70,344" />
-		<button name="VOL+" pos="36,349" />
-		<button name="BOUQUET+" pos="105,349" />
+		<button name="VOL-" pos="36,349" />
+		<button name="BOUQUET-" pos="105,349" />
 		<button name="MENU" pos="31,375" />
 		<button name="VIDEO" pos="57,375" />
 		<button name="AUDIO" pos="84,375" />

--- a/BoxBranding/remotes/vu/remote.html
+++ b/BoxBranding/remotes/vu/remote.html
@@ -29,8 +29,8 @@
 	<area shape="rect" coords="90,303,120,329" title="channel up" onclick="pressMenuRemote('402');">
 	<area shape="circle" coords="70,318,9" title="exit" onclick="pressMenuRemote('174');">
 	<area shape="circle" coords="70,344,9" title="epg" onclick="pressMenuRemote('358');">
-	<area shape="rect" coords="23,338,49,360" title="volume up" onclick="pressMenuRemote('115');">
-	<area shape="rect" coords="92,338,118,360" title="channel up" onclick="pressMenuRemote('402');">
+	<area shape="rect" coords="23,338,49,360" title="volume down" onclick="pressMenuRemote('114');">
+	<area shape="rect" coords="92,338,118,360" title="channel down" onclick="pressMenuRemote('403');">
 	<area shape="rect" coords="21,367,41,383" title="menu" onclick="pressMenuRemote('139');">
 	<area shape="rect" coords="47,367,67,383" title="pvr" onclick="pressMenuRemote('393');">
 	<area shape="rect" coords="74,367,94,383" title="audio" onclick="pressMenuRemote('392');">


### PR DESCRIPTION
Fix the data for CH- (BOUQUET-, channel down) and VOL- (volume down)
in rcpositions.xml & remote.xml.

The buttons had been previously incorrectly labelled for CH+ & VOL+.

Thanks to Huevos for pointing out the problem.